### PR TITLE
multi: refactor proof file format

### DIFF
--- a/asset/mock.go
+++ b/asset/mock.go
@@ -5,6 +5,7 @@ import (
 	"encoding/hex"
 	"testing"
 
+	"github.com/btcsuite/btcd/btcec/v2"
 	"github.com/lightninglabs/taro/internal/test"
 	"github.com/stretchr/testify/require"
 )
@@ -24,4 +25,18 @@ func RandGenesis(t testing.TB, assetType Type) Genesis {
 		OutputIndex:  uint32(test.RandInt[int32]()),
 		Type:         assetType,
 	}
+}
+
+// RandFamilyKey creates a random family key for testing.
+func RandFamilyKey(t testing.TB, genesis *Genesis) *FamilyKey {
+	privateKey, err := btcec.NewPrivateKey()
+	require.NoError(t, err)
+
+	genSigner := NewRawKeyGenesisSigner(privateKey)
+
+	familyKey, err := DeriveFamilyKey(
+		genSigner, test.PubToKeyDesc(privateKey.PubKey()), *genesis,
+	)
+	require.NoError(t, err)
+	return familyKey
 }

--- a/asset/mock.go
+++ b/asset/mock.go
@@ -10,7 +10,7 @@ import (
 )
 
 // RandGenesis creates a random genesis for testing.
-func RandGenesis(t *testing.T, assetType Type) Genesis {
+func RandGenesis(t testing.TB, assetType Type) Genesis {
 	t.Helper()
 
 	metadata := make([]byte, test.RandInt[int]()%32+1)

--- a/commitment/split.go
+++ b/commitment/split.go
@@ -7,7 +7,6 @@ import (
 	"errors"
 
 	"github.com/btcsuite/btcd/btcec/v2"
-
 	"github.com/btcsuite/btcd/wire"
 	"github.com/lightninglabs/taro/asset"
 	"github.com/lightninglabs/taro/mssmt"

--- a/internal/test/helpers.go
+++ b/internal/test/helpers.go
@@ -23,7 +23,7 @@ func RandInt[T constraints.Integer]() T {
 	return T(rand.Int63()) // nolint:gosec
 }
 
-func RandOp(t *testing.T) wire.OutPoint {
+func RandOp(t testing.TB) wire.OutPoint {
 	t.Helper()
 
 	op := wire.OutPoint{
@@ -35,23 +35,23 @@ func RandOp(t *testing.T) wire.OutPoint {
 	return op
 }
 
-func RandPrivKey(t *testing.T) *btcec.PrivateKey {
+func RandPrivKey(t testing.TB) *btcec.PrivateKey {
 	privKey, err := btcec.NewPrivateKey()
 	require.NoError(t, err)
 	return privKey
 }
 
-func SchnorrPubKey(t *testing.T, privKey *btcec.PrivateKey) *btcec.PublicKey {
+func SchnorrPubKey(t testing.TB, privKey *btcec.PrivateKey) *btcec.PublicKey {
 	return SchnorrKey(t, privKey.PubKey())
 }
 
-func SchnorrKey(t *testing.T, pubKey *btcec.PublicKey) *btcec.PublicKey {
+func SchnorrKey(t testing.TB, pubKey *btcec.PublicKey) *btcec.PublicKey {
 	key, err := schnorr.ParsePubKey(schnorr.SerializePubKey(pubKey))
 	require.NoError(t, err)
 	return key
 }
 
-func RandPubKey(t *testing.T) *btcec.PublicKey {
+func RandPubKey(t testing.TB) *btcec.PublicKey {
 	return SchnorrPubKey(t, RandPrivKey(t))
 }
 
@@ -67,7 +67,7 @@ func PubToKeyDesc(p *btcec.PublicKey) keychain.KeyDescriptor {
 	}
 }
 
-func ComputeTaprootScript(t *testing.T, taprootKey *btcec.PublicKey) []byte {
+func ComputeTaprootScript(t testing.TB, taprootKey *btcec.PublicKey) []byte {
 	script, err := txscript.NewScriptBuilder().
 		AddOp(txscript.OP_1).
 		AddData(schnorr.SerializePubKey(taprootKey)).

--- a/internal/test/helpers.go
+++ b/internal/test/helpers.go
@@ -6,7 +6,9 @@ import (
 
 	"github.com/btcsuite/btcd/btcec/v2"
 	"github.com/btcsuite/btcd/btcec/v2/schnorr"
+	"github.com/btcsuite/btcd/txscript"
 	"github.com/btcsuite/btcd/wire"
+	"github.com/lightningnetwork/lnd/keychain"
 	"github.com/stretchr/testify/require"
 	"golang.org/x/exp/constraints"
 )
@@ -57,4 +59,19 @@ func RandBytes(num int) []byte {
 	randBytes := make([]byte, num)
 	_, _ = rand.Read(randBytes)
 	return randBytes
+}
+
+func PubToKeyDesc(p *btcec.PublicKey) keychain.KeyDescriptor {
+	return keychain.KeyDescriptor{
+		PubKey: p,
+	}
+}
+
+func ComputeTaprootScript(t *testing.T, taprootKey *btcec.PublicKey) []byte {
+	script, err := txscript.NewScriptBuilder().
+		AddOp(txscript.OP_1).
+		AddData(schnorr.SerializePubKey(taprootKey)).
+		Script()
+	require.NoError(t, err)
+	return script
 }

--- a/itest/assertions.go
+++ b/itest/assertions.go
@@ -162,7 +162,7 @@ func assertAssetProofs(t *testing.T, tarod *tarodHarness,
 	assetJSON, err := formatProtoJSON(a)
 	require.NoError(t, err)
 	t.Logf("Got proof file for asset %x that contains %d proof(s), full "+
-		"asset: %s", a.AssetGenesis.AssetId, len(file.Proofs),
+		"asset: %s", a.AssetGenesis.AssetId, file.NumProofs(),
 		assetJSON)
 
 	require.Equal(

--- a/proof/append_test.go
+++ b/proof/append_test.go
@@ -18,7 +18,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func genTaprootKeySpend(t *testing.T, privKey btcec.PrivateKey,
+func genTaprootKeySpend(t testing.TB, privKey btcec.PrivateKey,
 	virtualTx *wire.MsgTx, input *asset.Asset, idx uint32) wire.TxWitness {
 
 	t.Helper()
@@ -369,7 +369,7 @@ func runAppendTransitionTest(t *testing.T, assetType asset.Type, amt uint64,
 // signAssetTransfer creates a virtual transaction for an asset transfer and
 // signs it with the given sender private key. Then we add the generated witness
 // to the root asset and all split asset's root asset references.
-func signAssetTransfer(t *testing.T, prevProof *Proof, newAsset *asset.Asset,
+func signAssetTransfer(t testing.TB, prevProof *Proof, newAsset *asset.Asset,
 	senderPrivKey *btcec.PrivateKey, splitAssets []*asset.Asset) {
 
 	prevOutpoint := wire.OutPoint{
@@ -410,7 +410,7 @@ func signAssetTransfer(t *testing.T, prevProof *Proof, newAsset *asset.Asset,
 	}
 }
 
-func verifyBlob(t *testing.T, blob Blob) *AssetSnapshot {
+func verifyBlob(t testing.TB, blob Blob) *AssetSnapshot {
 	// Decode the proof blob into a proper file structure first.
 	f := NewFile(V0)
 	require.NoError(t, f.Decode(bytes.NewReader(blob)))

--- a/proof/append_test.go
+++ b/proof/append_test.go
@@ -412,7 +412,7 @@ func signAssetTransfer(t testing.TB, prevProof *Proof, newAsset *asset.Asset,
 
 func verifyBlob(t testing.TB, blob Blob) *AssetSnapshot {
 	// Decode the proof blob into a proper file structure first.
-	f := NewFile(V0)
+	f := NewEmptyFile(V0)
 	require.NoError(t, f.Decode(bytes.NewReader(blob)))
 
 	finalSnapshot, err := f.Verify(context.Background())

--- a/proof/append_test.go
+++ b/proof/append_test.go
@@ -100,7 +100,7 @@ func runAppendTransitionTest(t *testing.T, assetType asset.Type, amt uint64,
 	recipientPrivKey := test.RandPrivKey(t)
 	newAsset := *genesisProof.Asset.Copy()
 	newAsset.ScriptKey = asset.NewScriptKeyBIP0086(
-		pubToKeyDesc(recipientPrivKey.PubKey()),
+		test.PubToKeyDesc(recipientPrivKey.PubKey()),
 	)
 	recipientTaprootInternalKey := test.SchnorrPubKey(t, recipientPrivKey)
 
@@ -116,7 +116,7 @@ func runAppendTransitionTest(t *testing.T, assetType asset.Type, amt uint64,
 	taprootKey := txscript.ComputeTaprootOutputKey(
 		recipientTaprootInternalKey, tapscriptRoot[:],
 	)
-	taprootScript := computeTaprootScript(t, taprootKey)
+	taprootScript := test.ComputeTaprootScript(t, taprootKey)
 
 	chainTx := &wire.MsgTx{
 		Version: 2,
@@ -140,8 +140,10 @@ func runAppendTransitionTest(t *testing.T, assetType asset.Type, amt uint64,
 			changeInternalKey,
 		)
 		chainTx.TxOut = append(chainTx.TxOut, &wire.TxOut{
-			PkScript: computeTaprootScript(t, changeTaprootKey),
-			Value:    333,
+			PkScript: test.ComputeTaprootScript(
+				t, changeTaprootKey,
+			),
+			Value: 333,
 		})
 	}
 
@@ -262,10 +264,10 @@ func runAppendTransitionTest(t *testing.T, assetType asset.Type, amt uint64,
 			},
 		}},
 		TxOut: []*wire.TxOut{{
-			PkScript: computeTaprootScript(t, taproot1Key),
+			PkScript: test.ComputeTaprootScript(t, taproot1Key),
 			Value:    330,
 		}, {
-			PkScript: computeTaprootScript(t, taproot2Key),
+			PkScript: test.ComputeTaprootScript(t, taproot2Key),
 			Value:    330,
 		}},
 	}

--- a/proof/file.go
+++ b/proof/file.go
@@ -7,8 +7,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
-	"math"
 
 	"github.com/btcsuite/btcd/btcec/v2"
 	"github.com/btcsuite/btcd/chaincfg/chainhash"
@@ -18,24 +16,14 @@ import (
 	"github.com/lightningnetwork/lnd/tlv"
 )
 
-const (
-	// MaxFileSize represents the maximum file size in bytes allowed for a
-	// proof file.
-	//
-	// TODO: Come up with a more sensible value.
-	MaxFileSize = math.MaxUint32
-)
-
 var (
 	// ErrInvalidChecksum is an error returned when an invalid proof file
 	// checksum is detected while deserializing it.
 	ErrInvalidChecksum = errors.New("invalid proof file checksum")
 
-	// ErrExceedsMaxFileSize is an error returned when a proof file exceeds
-	// the maximum size allowed.
-	ErrExceedsMaxFileSize = fmt.Errorf(
-		"proof file exceeds maximum size of %d bytes", MaxFileSize,
-	)
+	// ErrNoProofAvailable is the error that's returned when a proof is
+	// attempted to be fetched from an empty file.
+	ErrNoProofAvailable = errors.New("no proof available")
 )
 
 // Version denotes the versioning scheme for proof files.
@@ -46,24 +34,271 @@ const (
 	V0 Version = 0
 )
 
+// hashedProof is a struct that contains an encoded proof and its chained
+// checksum.
+type hashedProof struct {
+	// proofBytes is the encoded proof that is hashed.
+	proofBytes []byte
+
+	// hash is the SHA256 sum of (prev_hash || proof).
+	hash [sha256.Size]byte
+}
+
 // File represents a proof file comprised of proofs for all of an asset's state
 // transitions back to its genesis state.
 type File struct {
 	// Version is the version of the proof file.
 	Version Version
 
-	// Proofs are the proofs contained within the proof file starting from
+	// proofs are the proofs contained within the proof file starting from
 	// the genesis proof.
-	Proofs []Proof
+	proofs []*hashedProof
+}
+
+// NewEmptyFile returns a new empty file with the given version.
+func NewEmptyFile(v Version) *File {
+	return &File{
+		Version: v,
+	}
 }
 
 // NewFile returns a new proof file given a version and a series of state
 // transition proofs.
-func NewFile(v Version, proofs ...Proof) File {
-	return File{
-		Version: v,
-		Proofs:  proofs,
+func NewFile(v Version, proofs ...Proof) (*File, error) {
+	var (
+		prevHash     [sha256.Size]byte
+		linkedProofs = make([]*hashedProof, len(proofs))
+	)
+
+	// We start out with the zero hash as the previous hash and then create
+	// the checksum of SHA256(prev_hash || proof) as our incremental
+	// checksum for each of the proofs, basically building a proof chain
+	// similar to Bitcoin's time chain.
+	for idx := range proofs {
+		proof := proofs[idx]
+
+		proofBytes, err := encodeProof(&proof)
+		if err != nil {
+			return nil, err
+		}
+
+		linkedProofs[idx] = &hashedProof{
+			proofBytes: proofBytes,
+			hash:       hashProof(proofBytes, prevHash),
+		}
+		prevHash = linkedProofs[idx].hash
 	}
+
+	return &File{
+		Version: v,
+		proofs:  linkedProofs,
+	}, nil
+}
+
+// Encode encodes the proof file into `w` including its checksum.
+func (f *File) Encode(w io.Writer) error {
+	err := binary.Write(w, binary.BigEndian, uint32(f.Version))
+	if err != nil {
+		return err
+	}
+
+	var tlvBuf [8]byte
+	if err := tlv.WriteVarInt(w, uint64(len(f.proofs)), &tlvBuf); err != nil {
+		return err
+	}
+	for _, proof := range f.proofs {
+		proof := proof
+
+		// To the file we write the proof, followed by its hash, which
+		// is SHA256(prev_hash || proof). That way if we serially read
+		// the whole file using the zero hash as the first prev_hash,
+		// then we can make sure we have no data corruption if the
+		// serially built hash is equal to the last proof's hash. On the
+		// other hand, if we want to append a proof to a file, we just
+		// need to read the last proof, use its hash as the prev_hash
+		// for the one to append, and we're done.
+		err := tlv.WriteVarInt(w, uint64(len(proof.proofBytes)), &tlvBuf)
+		if err != nil {
+			return err
+		}
+		if _, err := w.Write(proof.proofBytes); err != nil {
+			return err
+		}
+
+		// The hash is not part of the proof's TLV stream, so we didn't
+		// count it above.
+		if _, err := w.Write(proof.hash[:]); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// Decode decodes a proof file from `r`.
+func (f *File) Decode(r io.Reader) error {
+	var version uint32
+	if err := binary.Read(r, binary.BigEndian, &version); err != nil {
+		return err
+	}
+	f.Version = Version(version)
+
+	var tlvBuf [8]byte
+	numProofs, err := tlv.ReadVarInt(r, &tlvBuf)
+	if err != nil {
+		return err
+	}
+
+	var prevHash, currentHash, proofHash [sha256.Size]byte
+	f.proofs = make([]*hashedProof, numProofs)
+	for i := uint64(0); i < numProofs; i++ {
+		// We need to find out how many bytes we expect for the proof,
+		// so we can limit the TLV reader.
+		numProofBytes, err := tlv.ReadVarInt(r, &tlvBuf)
+		if err != nil {
+			return err
+		}
+
+		// Read all bytes that belong to the proof. We don't decode the
+		// proof itself as we usually only need the last proof anyway.
+		proofBytes := make([]byte, numProofBytes)
+		if _, err := io.ReadFull(r, proofBytes); err != nil {
+			return err
+		}
+
+		// We now read the proof's hash in the file which reflects the
+		// current checksum.
+		if _, err := io.ReadFull(r, proofHash[:]); err != nil {
+			return err
+		}
+
+		// Now that we have read both the proof and the expected
+		// checksum of it, we calculate our own checksum and verify they
+		// match.
+		currentHash = hashProof(proofBytes, prevHash)
+		if proofHash != currentHash {
+			return ErrInvalidChecksum
+		}
+
+		f.proofs[i] = &hashedProof{
+			proofBytes: proofBytes,
+			hash:       currentHash,
+		}
+		prevHash = currentHash
+	}
+
+	return nil
+}
+
+// IsEmpty returns true if the file does not contain any proofs.
+func (f *File) IsEmpty() bool {
+	return len(f.proofs) == 0
+}
+
+// NumProofs returns the number of proofs contained in this file.
+func (f *File) NumProofs() int {
+	return len(f.proofs)
+}
+
+// ProofAt returns the proof at the given index. If the file is empty, this
+// returns nil.
+func (f *File) ProofAt(index uint32) (*Proof, error) {
+	if f.IsEmpty() {
+		return nil, ErrNoProofAvailable
+	}
+
+	if index > uint32(len(f.proofs))-1 {
+		return nil, fmt.Errorf("invalid index %d", index)
+	}
+
+	var (
+		proof  = &Proof{}
+		reader = bytes.NewReader(f.proofs[index].proofBytes)
+	)
+	if err := proof.Decode(reader); err != nil {
+		return nil, fmt.Errorf("error decoding proof: %v", err)
+	}
+
+	return proof, nil
+}
+
+// LastProof returns the last proof in the chain of proofs. If the file is
+// empty, this return nil.
+func (f *File) LastProof() (*Proof, error) {
+	if f.IsEmpty() {
+		return nil, ErrNoProofAvailable
+	}
+
+	return f.ProofAt(uint32(len(f.proofs)) - 1)
+}
+
+// AppendProof appends a proof to the file and calculates its chained hash.
+func (f *File) AppendProof(proof Proof) error {
+	var prevHash [sha256.Size]byte
+	if !f.IsEmpty() {
+		prevHash = f.proofs[len(f.proofs)-1].hash
+	}
+
+	proofBytes, err := encodeProof(&proof)
+	if err != nil {
+		return err
+	}
+
+	f.proofs = append(f.proofs, &hashedProof{
+		proofBytes: proofBytes,
+		hash:       hashProof(proofBytes, prevHash),
+	})
+
+	return nil
+}
+
+// ReplaceLastProof attempts to replace the last proof in the file with another
+// one, updating its chained hash in the process.
+func (f *File) ReplaceLastProof(proof Proof) error {
+	if f.IsEmpty() {
+		return fmt.Errorf("file is empty")
+	}
+
+	var prevHash [sha256.Size]byte
+	if f.NumProofs() > 1 {
+		// We want the prev_hash of the last proof, so we need to go
+		// back 2. If we're replacing the single proof of the file, then
+		// the prev_hash is the zero hash.
+		prevHash = f.proofs[len(f.proofs)-2].hash
+	}
+
+	proofBytes, err := encodeProof(&proof)
+	if err != nil {
+		return err
+	}
+
+	f.proofs[len(f.proofs)-1] = &hashedProof{
+		proofBytes: proofBytes,
+		hash:       hashProof(proofBytes, prevHash),
+	}
+
+	return nil
+}
+
+// encodeProof encodes the given proof and returns its raw bytes.
+func encodeProof(proof *Proof) ([]byte, error) {
+	var buf bytes.Buffer
+	if err := proof.Encode(&buf); err != nil {
+		return nil, err
+	}
+
+	return buf.Bytes(), nil
+}
+
+// hashProof hashes a proof's content together with the previous hash and
+// re-uses the given buffer:
+//
+//	SHA256(prev_hash || proof_bytes).
+func hashProof(proofBytes []byte, prevHash [32]byte) [32]byte {
+	h := sha256.New()
+	_, _ = h.Write(prevHash[:])
+	_, _ = h.Write(proofBytes)
+	return *(*[32]byte)(h.Sum(nil))
 }
 
 // AssetSnapshot commits to the result of a valid proof within a proof file.
@@ -105,106 +340,4 @@ type AssetSnapshot struct {
 	// resulted from splitting an asset. If this is true then the root asset
 	// of the split can be found in the asset witness' split commitment.
 	SplitAsset bool
-}
-
-// encodeNoChecksum encodes the proof file into `w` without its checksum.
-func (f *File) encodeNoChecksum(w io.Writer) error {
-	err := binary.Write(w, binary.BigEndian, uint32(f.Version))
-	if err != nil {
-		return err
-	}
-
-	var buf [8]byte
-	if err := tlv.WriteVarInt(w, uint64(len(f.Proofs)), &buf); err != nil {
-		return err
-	}
-	for _, proof := range f.Proofs {
-		var proofBuf bytes.Buffer
-		if err = proof.Encode(&proofBuf); err != nil {
-			return err
-		}
-		err := tlv.WriteVarInt(w, uint64(len(proofBuf.Bytes())), &buf)
-		if err != nil {
-			return err
-		}
-		proofBytes := proofBuf.Bytes()
-		if err := tlv.EVarBytes(w, &proofBytes, &buf); err != nil {
-			return err
-		}
-	}
-
-	return nil
-}
-
-// Encode encodes the proof file into `w` including its checksum.
-func (f *File) Encode(w io.Writer) error {
-	var buf bytes.Buffer
-	if err := f.encodeNoChecksum(&buf); err != nil {
-		return err
-	}
-	checksum := sha256.Sum256(buf.Bytes())
-	if _, err := w.Write(checksum[:]); err != nil {
-		return err
-	}
-	if _, err := w.Write(buf.Bytes()); err != nil {
-		return err
-	}
-	return nil
-}
-
-// Decode decodes a proof file from `r`.
-func (f *File) Decode(r io.Reader) error {
-	// Verify that the checksum is valid before processing the file's
-	// contents.
-	var checksum [32]byte
-	if _, err := r.Read(checksum[:]); err != nil {
-		return err
-	}
-
-	// Simple DoS prevention measure for too large proof files.
-	fileLimit := &io.LimitedReader{R: r, N: MaxFileSize}
-	fileBytes, err := ioutil.ReadAll(fileLimit)
-	if err != nil {
-		if fileLimit.N <= 0 {
-			return ErrExceedsMaxFileSize
-		}
-		return err
-	}
-	if sha256.Sum256(fileBytes) != checksum {
-		return ErrInvalidChecksum
-	}
-
-	file := bytes.NewReader(fileBytes)
-
-	var version uint32
-	if err = binary.Read(file, binary.BigEndian, &version); err != nil {
-		return err
-	}
-	f.Version = Version(version)
-
-	var buf [8]byte
-	numProofs, err := tlv.ReadVarInt(file, &buf)
-	if err != nil {
-		return err
-	}
-	f.Proofs = make([]Proof, 0, numProofs)
-	for i := uint64(0); i < numProofs; i++ {
-		proofLen, err := tlv.ReadVarInt(file, &buf)
-		if err != nil {
-			return err
-		}
-		var serializedProof []byte
-		err = tlv.DVarBytes(file, &serializedProof, &buf, proofLen)
-		if err != nil {
-			return err
-		}
-		var proof Proof
-		err = proof.Decode(bytes.NewReader(serializedProof))
-		if err != nil {
-			return err
-		}
-		f.Proofs = append(f.Proofs, proof)
-	}
-
-	return nil
 }

--- a/proof/mint.go
+++ b/proof/mint.go
@@ -62,16 +62,15 @@ type MintParams struct {
 }
 
 // encodeAsProofFile encodes the passed proof into a blob.
-//
-// TODO(roasbeef): change main file to use pointers instead?
 func encodeAsProofFile(proof *Proof) (Blob, error) {
-	proofFile := NewFile(V0, *proof)
+	proofFile, err := NewFile(V0, *proof)
+	if err != nil {
+		return nil, err
+	}
 
 	var b bytes.Buffer
 	if err := proofFile.Encode(&b); err != nil {
-		// TODO(roasbeef): proper error
-		return nil, fmt.Errorf("unable to encode proof "+
-			"file: %w", err)
+		return nil, fmt.Errorf("unable to encode proof file: %w", err)
 	}
 
 	return b.Bytes(), nil

--- a/proof/mint_test.go
+++ b/proof/mint_test.go
@@ -26,7 +26,7 @@ func TestNewMintingBlobs(t *testing.T) {
 		genesisPrivKey.PubKey(),
 	)
 	assetGenesis := asset.RandGenesis(t, asset.Collectible)
-	assetFamilyKey := randFamilyKey(t, &assetGenesis)
+	assetFamilyKey := asset.RandFamilyKey(t, &assetGenesis)
 	taroCommitment, _, err := commitment.Mint(
 		assetGenesis, assetFamilyKey, &commitment.AssetDetails{
 			Type:             asset.Collectible,

--- a/proof/mint_test.go
+++ b/proof/mint_test.go
@@ -30,7 +30,7 @@ func TestNewMintingBlobs(t *testing.T) {
 	taroCommitment, _, err := commitment.Mint(
 		assetGenesis, assetFamilyKey, &commitment.AssetDetails{
 			Type:             asset.Collectible,
-			ScriptKey:        pubToKeyDesc(genesisScriptKey),
+			ScriptKey:        test.PubToKeyDesc(genesisScriptKey),
 			Amount:           nil,
 			LockTime:         0,
 			RelativeLockTime: 0,
@@ -43,7 +43,7 @@ func TestNewMintingBlobs(t *testing.T) {
 	taprootKey := txscript.ComputeTaprootOutputKey(
 		internalKey, tapscriptRoot[:],
 	)
-	taprootScript := computeTaprootScript(t, taprootKey)
+	taprootScript := test.ComputeTaprootScript(t, taprootKey)
 
 	changeInternalKey := test.RandPrivKey(t).PubKey()
 	changeTaprootKey := txscript.ComputeTaprootKeyNoScript(
@@ -57,8 +57,10 @@ func TestNewMintingBlobs(t *testing.T) {
 			PkScript: taprootScript,
 			Value:    330,
 		}, {
-			PkScript: computeTaprootScript(t, changeTaprootKey),
-			Value:    333,
+			PkScript: test.ComputeTaprootScript(
+				t, changeTaprootKey,
+			),
+			Value: 333,
 		}},
 	}
 

--- a/proof/mint_test.go
+++ b/proof/mint_test.go
@@ -25,10 +25,10 @@ func TestNewMintingBlobs(t *testing.T) {
 	genesisScriptKey := txscript.ComputeTaprootKeyNoScript(
 		genesisPrivKey.PubKey(),
 	)
-	assetGenesis := randGenesis(t, asset.Collectible)
-	assetFamilyKey := randFamilyKey(t, assetGenesis)
+	assetGenesis := asset.RandGenesis(t, asset.Collectible)
+	assetFamilyKey := randFamilyKey(t, &assetGenesis)
 	taroCommitment, _, err := commitment.Mint(
-		*assetGenesis, assetFamilyKey, &commitment.AssetDetails{
+		assetGenesis, assetFamilyKey, &commitment.AssetDetails{
 			Type:             asset.Collectible,
 			ScriptKey:        pubToKeyDesc(genesisScriptKey),
 			Amount:           nil,

--- a/proof/proof_test.go
+++ b/proof/proof_test.go
@@ -70,11 +70,8 @@ func computeTaprootScript(t *testing.T, taprootKey *btcec.PublicKey) []byte {
 }
 
 func assertEqualCommitmentProof(t *testing.T, expected, actual *CommitmentProof) {
-	require.Equal(t, expected.Proof.AssetProof.Version, actual.Proof.AssetProof.Version)
-	require.Equal(t, expected.Proof.AssetProof.AssetID, actual.Proof.AssetProof.AssetID)
-	require.Equal(t, expected.Proof.AssetProof.Proof, actual.Proof.AssetProof.Proof)
-	require.Equal(t, expected.Proof.TaroProof.Version, actual.Proof.TaroProof.Version)
-	require.Equal(t, expected.Proof.TaroProof.Proof, actual.Proof.TaroProof.Proof)
+	require.Equal(t, expected.Proof.AssetProof, actual.Proof.AssetProof)
+	require.Equal(t, expected.Proof.TaroProof, actual.Proof.TaroProof)
 	require.Equal(t, expected.TapSiblingPreimage, actual.TapSiblingPreimage)
 }
 

--- a/proof/proof_test.go
+++ b/proof/proof_test.go
@@ -19,19 +19,6 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func randFamilyKey(t *testing.T, genesis *asset.Genesis) *asset.FamilyKey {
-	privKey, err := btcec.NewPrivateKey()
-	require.NoError(t, err)
-
-	genSigner := asset.NewRawKeyGenesisSigner(privKey)
-
-	familyKey, err := asset.DeriveFamilyKey(
-		genSigner, test.PubToKeyDesc(privKey.PubKey()), *genesis,
-	)
-	require.NoError(t, err)
-	return familyKey
-}
-
 func assertEqualCommitmentProof(t *testing.T, expected, actual *CommitmentProof) {
 	require.Equal(t, expected.Proof.AssetProof, actual.Proof.AssetProof)
 	require.Equal(t, expected.Proof.TaroProof, actual.Proof.TaroProof)
@@ -101,7 +88,7 @@ func TestProofEncoding(t *testing.T) {
 	require.NoError(t, err)
 
 	genesis := asset.RandGenesis(t, asset.Collectible)
-	familyKey := randFamilyKey(t, &genesis)
+	familyKey := asset.RandFamilyKey(t, &genesis)
 
 	commitment, assets, err := commitment.Mint(
 		genesis, familyKey, &commitment.AssetDetails{
@@ -208,14 +195,14 @@ func TestProofEncoding(t *testing.T) {
 	assertEqualProof(t, &proof, &decodedProof)
 }
 
-func genRandomGenesisWithProof(t *testing.T, assetType asset.Type,
+func genRandomGenesisWithProof(t testing.TB, assetType asset.Type,
 	amt *uint64) (Proof, *btcec.PrivateKey) {
 
 	t.Helper()
 
 	genesisPrivKey := test.RandPrivKey(t)
 	assetGenesis := asset.RandGenesis(t, assetType)
-	assetFamilyKey := randFamilyKey(t, &assetGenesis)
+	assetFamilyKey := asset.RandFamilyKey(t, &assetGenesis)
 	taroCommitment, assets, err := commitment.Mint(
 		assetGenesis, assetFamilyKey, &commitment.AssetDetails{
 			Type: assetType,

--- a/proof/verifier.go
+++ b/proof/verifier.go
@@ -321,15 +321,19 @@ func (f *File) Verify(ctx context.Context) (*AssetSnapshot, error) {
 	}
 
 	var prev *AssetSnapshot
-	for _, proof := range f.Proofs {
+	for idx := range f.proofs {
 		select {
 		case <-ctx.Done():
 			return nil, ctx.Err()
 		default:
 		}
 
-		proof := proof
-		result, err := proof.Verify(ctx, prev)
+		decodedProof, err := f.ProofAt(uint32(idx))
+		if err != nil {
+			return nil, err
+		}
+
+		result, err := decodedProof.Verify(ctx, prev)
 		if err != nil {
 			return nil, err
 		}

--- a/tarofreighter/chain_porter.go
+++ b/tarofreighter/chain_porter.go
@@ -325,7 +325,7 @@ func (p *ChainPorter) waitForPkgConfirmation(pkg *OutboundParcelDelta) {
 		p.cfg.ErrChan <- mkErr("error fetching proof: %v", err)
 		return
 	}
-	var senderProof proof.File
+	senderProof := proof.NewEmptyFile(proof.V0)
 	err = senderProof.Decode(bytes.NewReader(senderFullProofBytes))
 	if err != nil {
 		p.cfg.ErrChan <- mkErr("error decoding proof: %v", err)
@@ -356,7 +356,10 @@ func (p *ChainPorter) waitForPkgConfirmation(pkg *OutboundParcelDelta) {
 	// With the proof suffix updated, we can append the proof, then encode
 	// it to get the final sender proof.
 	var updatedSenderProof bytes.Buffer
-	senderProof.Proofs = append(senderProof.Proofs, senderProofSuffix)
+	if err := senderProof.AppendProof(senderProofSuffix); err != nil {
+		p.cfg.ErrChan <- mkErr("error appending sender proof: %v", err)
+		return
+	}
 	if err := senderProof.Encode(&updatedSenderProof); err != nil {
 		p.cfg.ErrChan <- mkErr("error encoding sender proof: %v", err)
 		return
@@ -387,7 +390,10 @@ func (p *ChainPorter) waitForPkgConfirmation(pkg *OutboundParcelDelta) {
 	// Now we'll write out the final receiver proof to the on disk proof
 	// archive.
 	var updatedReceiverProof bytes.Buffer
-	senderProof.Proofs[len(senderProof.Proofs)-1] = receiverProofSuffix
+	if err := senderProof.ReplaceLastProof(receiverProofSuffix); err != nil {
+		p.cfg.ErrChan <- mkErr("error replacing receiver proof: %v", err)
+		return
+	}
 	if err := senderProof.Encode(&updatedReceiverProof); err != nil {
 		p.cfg.ErrChan <- mkErr("error encoding receiver proof: %v", err)
 		return
@@ -406,7 +412,7 @@ func (p *ChainPorter) waitForPkgConfirmation(pkg *OutboundParcelDelta) {
 	}
 
 	log.Debugf("Updated proofs for sender and receiver (new_len=%d)",
-		len(senderProof.Proofs))
+		senderProof.NumProofs())
 
 	// If we have a proof courier instance active, then we'll launch a new
 	// goroutine to deliver the proof to the receiver.

--- a/tarogarden/custodian.go
+++ b/tarogarden/custodian.go
@@ -479,22 +479,25 @@ func (c *Custodian) checkProofAvailable(event *address.Event) error {
 		return fmt.Errorf("error fetching proof for event: %w", err)
 	}
 
-	file := &proof.File{}
+	file := proof.NewEmptyFile(proof.V0)
 	if err := file.Decode(bytes.NewReader(blob)); err != nil {
 		return fmt.Errorf("error decoding proof file: %w", err)
 	}
 
 	// Exit early on empty proof (shouldn't happen outside of test cases).
-	if len(file.Proofs) == 0 {
+	if file.IsEmpty() {
 		return fmt.Errorf("archive contained empty proof file: %w", err)
 	}
 
-	lastProof := file.Proofs[len(file.Proofs)-1]
+	lastProof, err := file.LastProof()
+	if err != nil {
+		return fmt.Errorf("error fetching last proof: %w", err)
+	}
 
 	// The proof might be an old state, let's make sure it matches our event
 	// before marking the inbound asset transfer as complete.
 	if AddrMatchesAsset(event.Addr, &lastProof.Asset) {
-		return c.setReceiveCompleted(event, lastProof)
+		return c.setReceiveCompleted(event, *lastProof)
 	}
 
 	return nil
@@ -504,13 +507,13 @@ func (c *Custodian) checkProofAvailable(event *address.Event) error {
 // and pending address event. If a proof successfully matches the desired state
 // of the address, that completes the inbound transfer of an asset.
 func (c *Custodian) mapProofToEvent(p proof.Blob) error {
-	file := &proof.File{}
+	file := proof.NewEmptyFile(proof.V0)
 	if err := file.Decode(bytes.NewReader(p)); err != nil {
 		return fmt.Errorf("error decoding proof file: %w", err)
 	}
 
 	// Exit early on empty proof (shouldn't happen outside of test cases).
-	if len(file.Proofs) == 0 {
+	if file.IsEmpty() {
 		log.Warnf("Received empty proof file!")
 		return nil
 	}
@@ -518,9 +521,12 @@ func (c *Custodian) mapProofToEvent(p proof.Blob) error {
 	// We got the proof from the multi archiver, which verifies it before
 	// giving it to us. So we don't have to verify them again and can
 	// directly look at the last state.
-	lastProof := file.Proofs[len(file.Proofs)-1]
+	lastProof, err := file.LastProof()
+	if err != nil {
+		return fmt.Errorf("error fetching last proof: %w", err)
+	}
 	log.Infof("Received new proof file, version=%d, num_proofs=%d",
-		file.Version, len(file.Proofs))
+		file.Version, file.NumProofs())
 
 	// Check if any of our in-flight events match the last proof's state.
 	for _, event := range c.events {
@@ -529,7 +535,7 @@ func (c *Custodian) mapProofToEvent(p proof.Blob) error {
 			// database. Therefore, all we need to do is update the
 			// state of the address event to mark it as completed
 			// successfully.
-			return c.setReceiveCompleted(event, lastProof)
+			return c.setReceiveCompleted(event, *lastProof)
 		}
 	}
 

--- a/taroscript/send_test.go
+++ b/taroscript/send_test.go
@@ -1451,9 +1451,13 @@ func TestProofVerify(t *testing.T) {
 	// Create a proof for the genesis of asset 2.
 	createGenesisProof(t, &state)
 
-	genesisProofFile := proof.NewFile(proof.V0, state.asset2GenesisProof)
+	genesisProofFile, err := proof.NewFile(
+		proof.V0, state.asset2GenesisProof,
+	)
+	require.NoError(t, err)
+
 	var b bytes.Buffer
-	err := genesisProofFile.Encode(&b)
+	err = genesisProofFile.Encode(&b)
 	require.NoError(t, err)
 	genesisProofBlob := b.Bytes()
 
@@ -1591,7 +1595,7 @@ func TestProofVerify(t *testing.T) {
 		genesisProofBlob, &senderParams,
 	)
 	require.NoError(t, err)
-	senderFile := proof.NewFile(proof.V0)
+	senderFile := proof.NewEmptyFile(proof.V0)
 	require.NoError(t, senderFile.Decode(bytes.NewReader(senderBlob)))
 	_, err = senderFile.Verify(context.TODO())
 	require.NoError(t, err)
@@ -1600,7 +1604,7 @@ func TestProofVerify(t *testing.T) {
 		genesisProofBlob, &receiverParams,
 	)
 	require.NoError(t, err)
-	receiverFile := proof.NewFile(proof.V0)
+	receiverFile := proof.NewEmptyFile(proof.V0)
 	require.NoError(t, receiverFile.Decode(bytes.NewReader(receiverBlob)))
 	_, err = receiverFile.Verify(context.TODO())
 	require.NoError(t, err)


### PR DESCRIPTION
Fixes https://github.com/lightninglabs/taro/issues/57.

With this commit we change the proof file's format to a proof chain. Every proof is hashed with its previous proof's hash (the first proof will have a zero prev hash) to get to the proof's rolling checksum. That way a file can be read serially, proof-by-proof, without needing to load the full file content into memory. This also allows us to append a proof to an existing file easily, once we have a seekable proof reader that can read just the last proof of a file.
