### PR TITLE
tarofreighter: fix semantic error when accounting for fee delta 

### DIFF
--- a/tarofreighter/parcel.go
+++ b/tarofreighter/parcel.go
@@ -325,10 +325,10 @@ func (s *sendPackage) addAnchorPsbtInput() error {
 	lastIdx := len(s.SendPkt.UnsignedTx.TxOut) - 1
 	currentFee := inputAmt - outputAmt
 	feeDelta := int64(requiredFee) - currentFee
-	s.SendPkt.UnsignedTx.TxOut[lastIdx].Value += feeDelta
+	s.SendPkt.UnsignedTx.TxOut[lastIdx].Value -= feeDelta
 
-	log.Infof("Adjusting send pkt by factor of %v from %v sats to %v sats",
-		feeDelta, currentFee, requiredFee)
+	log.Infof("Adjusting send pkt by delta of %v from %v sats to %v sats",
+		feeDelta, int64(currentFee), int64(requiredFee))
 
 	return nil
 }


### PR DESCRIPTION
Fixes a bug where we wouldn't add the fee rather than subtract it from the output, which is what'll actually siphon off those additional fees to miners. Also fixes a log message as well to ensure it's all printed out in sats.

