### PR TITLE
multi: properly read split commitment roots from disk, eliminate unwarranted input asset mutation 

### DIFF
--- a/chanutils/func.go
+++ b/chanutils/func.go
@@ -32,3 +32,27 @@ func CopyAll[T Copyable[T]](xs []T) []T {
 
 	return newItems
 }
+
+// CopyableErr is a generic interface for a type that's able to return a deep copy
+// of itself. This is identical to Copyable, but shuold be used in cases where
+// the copy method can return an error.
+type CopyableErr[T any] interface {
+	Copy() (T, error)
+}
+
+// CopyAll creates a new slice where each item of the slice is a deep copy of
+// the elements of the input slice. This is identical to CopyAll, but shuold be
+// used in cases where the copy method can return an error.
+func CopyAllErr[T CopyableErr[T]](xs []T) ([]T, error) {
+	var err error
+
+	newItems := make([]T, len(xs))
+	for i := range xs {
+		newItems[i], err = xs[i].Copy()
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	return newItems, nil
+}

--- a/chanutils/func.go
+++ b/chanutils/func.go
@@ -15,3 +15,20 @@ func Reduce[T any, V any, S []V](s S, f Reducer[T, V]) T {
 
 	return accum
 }
+
+// Copyable is a generic interface for a type that's able to return a deep copy
+// of itself.
+type Copyable[T any] interface {
+	Copy() T
+}
+
+// CopyAll creates a new slice where each item of the slice is a deep copy of
+// the elements of the input slice.
+func CopyAll[T Copyable[T]](xs []T) []T {
+	newItems := make([]T, len(xs))
+	for i := range xs {
+		newItems[i] = xs[i].Copy()
+	}
+
+	return newItems
+}

--- a/chanutils/func.go
+++ b/chanutils/func.go
@@ -56,3 +56,17 @@ func CopyAllErr[T CopyableErr[T]](xs []T) ([]T, error) {
 
 	return newItems, nil
 }
+
+// All returns true if the passed predicate returns true for all items in the
+// slice.
+func All[T any](xs []T, pred func(T) bool) bool {
+	for _, x := range xs {
+		x := x
+
+		if !pred(x) {
+			return false
+		}
+	}
+
+	return true
+}

--- a/commitment/commitment_test.go
+++ b/commitment/commitment_test.go
@@ -900,14 +900,16 @@ func TestUpdateTaroCommitment(t *testing.T) {
 func TestAssetCommitmentDeepCopy(t *testing.T) {
 	t.Parallel()
 
+	// First, we'll make a commitment with two random assets.
 	genesis := randGenesis(t, asset.Normal)
-
 	asset1 := randAsset(t, genesis, nil)
 	asset2 := randAsset(t, genesis, nil)
 
 	assetCommitment, err := NewAssetCommitment(asset1, asset2)
 	require.NoError(t, err)
 
+	// Next, we'll copy the commitment and ensure that we get the exact
+	// same commitment out the other side.
 	assetCommitmentCopy, err := assetCommitment.Copy()
 	require.NoError(t, err)
 
@@ -917,5 +919,43 @@ func TestAssetCommitmentDeepCopy(t *testing.T) {
 		t, mssmt.IsEqualNode(
 			assetCommitment.TreeRoot, assetCommitmentCopy.TreeRoot,
 		),
+	)
+}
+
+// TestTaroCommitmentDeepCopy tests that we're able to properly perform a deep
+// copy of a given taro commitment.
+func TestTaroCommitmentDeepCopy(t *testing.T) {
+	t.Parallel()
+
+	// Fist, we'll make two asset commitments with a random asset, then
+	// make a taro commitment out of that.
+	genesis1 := randGenesis(t, asset.Normal)
+	familyKey1 := randFamilyKey(t, genesis1)
+	asset1 := randAsset(t, genesis1, familyKey1)
+
+	genesis2 := randGenesis(t, asset.Normal)
+	familyKey2 := randFamilyKey(t, genesis2)
+	asset2 := randAsset(t, genesis2, familyKey2)
+
+	assetCommitment1, err := NewAssetCommitment(asset1)
+	require.NoError(t, err)
+
+	assetCommitment2, err := NewAssetCommitment(asset2)
+	require.NoError(t, err)
+
+	// With both commitments created, we'll now make a new taro commitment
+	// then copy it.
+	taroCommitment, err := NewTaroCommitment(
+		assetCommitment1, assetCommitment2,
+	)
+	require.NoError(t, err)
+
+	newCommitment, err := taroCommitment.Copy()
+	require.NoError(t, err)
+
+	// The new taro commitment should match the existing one exactly.
+	require.Equal(t, taroCommitment.Version, newCommitment.Version)
+	require.True(t, mssmt.IsEqualNode(
+		taroCommitment.TreeRoot, newCommitment.TreeRoot),
 	)
 }

--- a/commitment/commitment_test.go
+++ b/commitment/commitment_test.go
@@ -894,3 +894,28 @@ func TestUpdateTaroCommitment(t *testing.T) {
 	require.Equal(t, len(assetCommitments), 2)
 	require.Equal(t, assetCommitments[commitmentKey2], assetCommitment2)
 }
+
+// TestAssetCommitmentDeepCopy tests that we're able to properly perform a deep
+// copy of a given asset commitment.
+func TestAssetCommitmentDeepCopy(t *testing.T) {
+	t.Parallel()
+
+	genesis := randGenesis(t, asset.Normal)
+
+	asset1 := randAsset(t, genesis, nil)
+	asset2 := randAsset(t, genesis, nil)
+
+	assetCommitment, err := NewAssetCommitment(asset1, asset2)
+	require.NoError(t, err)
+
+	assetCommitmentCopy, err := assetCommitment.Copy()
+	require.NoError(t, err)
+
+	require.Equal(t, assetCommitment.Version, assetCommitmentCopy.Version)
+	require.Equal(t, assetCommitment.AssetID, assetCommitmentCopy.AssetID)
+	require.True(
+		t, mssmt.IsEqualNode(
+			assetCommitment.TreeRoot, assetCommitmentCopy.TreeRoot,
+		),
+	)
+}

--- a/itest/send_test.go
+++ b/itest/send_test.go
@@ -1,0 +1,75 @@
+package itest
+
+import (
+	"bytes"
+	"context"
+
+	"github.com/lightninglabs/taro/chanutils"
+	"github.com/lightninglabs/taro/tarorpc"
+	"github.com/lightningnetwork/lnd/lntest/wait"
+	"github.com/stretchr/testify/require"
+)
+
+// testBasicSend tests that we can properly send assets back and forth between
+// nodes.
+func testBasicSend(t *harnessTest) {
+	// First, we'll make an normal assets with enough units to allow us to
+	// send it around a few times.
+	rpcAssets := mintAssetsConfirmBatch(
+		t, t.tarod, []*tarorpc.MintAssetRequest{simpleAssets[0]},
+	)
+
+	genBootstrap := rpcAssets[0].AssetGenesis.GenesisBootstrapInfo
+
+	ctxb := context.Background()
+
+	// Now that we have the asset created, we'll make a new node that'll
+	// serve as the node which'll receive the assets.
+	secondTarod := setupTarodHarness(
+		t.t, t, t.lndHarness.BackendCfg, t.lndHarness.Bob, t.universeServer,
+	)
+	defer func() {
+		require.NoError(t.t, secondTarod.stop(true))
+	}()
+
+	// Next, we'll attempt to complete two transfers with distinct
+	// addresses from our main node to Bob.
+	const (
+		numUnits = 10
+		numSends = 2
+	)
+	for i := 0; i < numSends; i++ {
+		bobAddr, err := secondTarod.NewAddr(ctxb, &tarorpc.NewAddrRequest{
+			GenesisBootstrapInfo: genBootstrap,
+			Amt:                  numUnits,
+		})
+		require.NoError(t.t, err)
+
+		assertAddrCreated(t.t, secondTarod, rpcAssets[0], bobAddr)
+
+		sendResp := sendAssetsToAddr(t, bobAddr)
+		sendRespJSON, err := formatProtoJSON(sendResp)
+		require.NoError(t.t, err)
+		t.Logf("Got response from sending assets: %v", sendRespJSON)
+
+		// Mine a block to force the send we created above to confirm.
+		_ = mineBlocks(t, t.lndHarness, 1, len(rpcAssets))
+
+		// Confirm that we can externally view the transfer.
+		err = wait.Predicate(func() bool {
+			resp, err := t.tarod.ListTransfers(
+				ctxb, &tarorpc.ListTransfersRequest{},
+			)
+			require.NoError(t.t, err)
+			require.Len(t.t, resp.Transfers, i+1)
+
+			sameAssetID := func(xfer *tarorpc.AssetTransfer) bool {
+				return bytes.Equal(xfer.AssetSpendDeltas[0].AssetId,
+					rpcAssets[0].AssetGenesis.AssetId)
+			}
+
+			return chanutils.All(resp.Transfers, sameAssetID)
+		}, defaultTimeout/2)
+		require.NoError(t.t, err)
+	}
+}

--- a/itest/test_list_on_test.go
+++ b/itest/test_list_on_test.go
@@ -12,4 +12,8 @@ var testCases = []*testCase{
 		name: "addresses",
 		test: testAddresses,
 	},
+	{
+		name: "basic send",
+		test: testBasicSend,
+	},
 }

--- a/rpcserver.go
+++ b/rpcserver.go
@@ -963,6 +963,8 @@ func (r *rpcServer) SendAsset(ctx context.Context,
 	newOutputs := make([]*tarorpc.AssetOutput, len(resp.AssetOutputs))
 
 	for i, input := range resp.AssetInputs {
+		input := input
+
 		prevInputs[i] = &tarorpc.PrevInputAsset{
 			AnchorPoint: input.PrevID.OutPoint.String(),
 			AssetId:     input.PrevID.ID[:],
@@ -971,6 +973,8 @@ func (r *rpcServer) SendAsset(ctx context.Context,
 		}
 	}
 	for i, output := range resp.AssetOutputs {
+		output := output
+
 		newOutputs[i] = &tarorpc.AssetOutput{
 			AnchorPoint: output.PrevID.OutPoint.String(),
 			AssetId:     output.PrevID.ID[:],

--- a/tarodb/assets_store.go
+++ b/tarodb/assets_store.go
@@ -484,6 +484,16 @@ func dbAssetsToChainAssets(dbAssets []ConfirmedAsset,
 				"%v", err)
 		}
 
+		if len(sprout.SplitCommitmentRootHash) != 0 {
+			var nodeHash mssmt.NodeHash
+			copy(nodeHash[:], sprout.SplitCommitmentRootHash)
+
+			assetSprout.SplitCommitmentRoot = mssmt.NewComputedNode(
+				nodeHash,
+				uint64(sprout.SplitCommitmentRootValue.Int64),
+			)
+		}
+
 		// With the asset created, we'll now emplace the set of
 		// witnesses for the asset itself. If this is a genesis asset,
 		// then it won't have a set of witnesses.

--- a/tarodb/assets_store_test.go
+++ b/tarodb/assets_store_test.go
@@ -848,6 +848,12 @@ func TestAssetExportLog(t *testing.T) {
 		// and amount.
 		if chainAsset.ScriptKey.PubKey.IsEqual(newScriptKey.PubKey) {
 			require.True(t, chainAsset.Amount == uint64(newAmt))
+			require.True(
+				t, mssmt.IsEqualNode(
+					chainAsset.SplitCommitmentRoot,
+					spendDelta.AssetSpendDeltas[0].SplitCommitmentRoot,
+				), "split roots don't match",
+			)
 			mutationFound = true
 		}
 	}

--- a/tarodb/sqlite.go
+++ b/tarodb/sqlite.go
@@ -66,6 +66,10 @@ func NewSqliteStore(cfg *SqliteConfig) (*SqliteStore, error) {
 			name:  "journal_mode",
 			value: "WAL",
 		},
+		{
+			name:  "busy_timeout",
+			value: "5000",
+		},
 	}
 	sqliteOptions := make(url.Values)
 	for _, option := range pragmaOptions {

--- a/tarodb/sqlite/assets.sql.go
+++ b/tarodb/sqlite/assets.sql.go
@@ -1390,7 +1390,8 @@ SELECT
     genesis_info_view.prev_out AS genesis_prev_out,
     txns.raw_tx AS anchor_tx, txns.txid AS anchor_txid, txns.block_hash AS anchor_block_hash,
     utxos.outpoint AS anchor_outpoint,
-    utxo_internal_keys.raw_key AS anchor_internal_key
+    utxo_internal_keys.raw_key AS anchor_internal_key,
+    split_commitment_root_hash, split_commitment_root_value
 FROM assets
 JOIN genesis_info_view
     ON assets.genesis_id = genesis_info_view.gen_asset_id AND
@@ -1425,34 +1426,36 @@ type QueryAssetsParams struct {
 }
 
 type QueryAssetsRow struct {
-	AssetPrimaryKey    int32
-	GenesisID          int32
-	Version            int32
-	ScriptKeyTweak     []byte
-	TweakedScriptKey   []byte
-	ScriptKeyRaw       []byte
-	ScriptKeyFam       int32
-	ScriptKeyIndex     int32
-	GenesisSig         []byte
-	TweakedFamKey      []byte
-	FamKeyRaw          []byte
-	FamKeyFamily       sql.NullInt32
-	FamKeyIndex        sql.NullInt32
-	ScriptVersion      int32
-	Amount             int64
-	LockTime           sql.NullInt32
-	RelativeLockTime   sql.NullInt32
-	AssetID            []byte
-	AssetTag           string
-	MetaData           []byte
-	GenesisOutputIndex int32
-	AssetType          int16
-	GenesisPrevOut     []byte
-	AnchorTx           []byte
-	AnchorTxid         []byte
-	AnchorBlockHash    []byte
-	AnchorOutpoint     []byte
-	AnchorInternalKey  []byte
+	AssetPrimaryKey          int32
+	GenesisID                int32
+	Version                  int32
+	ScriptKeyTweak           []byte
+	TweakedScriptKey         []byte
+	ScriptKeyRaw             []byte
+	ScriptKeyFam             int32
+	ScriptKeyIndex           int32
+	GenesisSig               []byte
+	TweakedFamKey            []byte
+	FamKeyRaw                []byte
+	FamKeyFamily             sql.NullInt32
+	FamKeyIndex              sql.NullInt32
+	ScriptVersion            int32
+	Amount                   int64
+	LockTime                 sql.NullInt32
+	RelativeLockTime         sql.NullInt32
+	AssetID                  []byte
+	AssetTag                 string
+	MetaData                 []byte
+	GenesisOutputIndex       int32
+	AssetType                int16
+	GenesisPrevOut           []byte
+	AnchorTx                 []byte
+	AnchorTxid               []byte
+	AnchorBlockHash          []byte
+	AnchorOutpoint           []byte
+	AnchorInternalKey        []byte
+	SplitCommitmentRootHash  []byte
+	SplitCommitmentRootValue sql.NullInt64
 }
 
 // We use a LEFT JOIN here as not every asset has a family key, so this'll
@@ -1506,6 +1509,8 @@ func (q *Queries) QueryAssets(ctx context.Context, arg QueryAssetsParams) ([]Que
 			&i.AnchorBlockHash,
 			&i.AnchorOutpoint,
 			&i.AnchorInternalKey,
+			&i.SplitCommitmentRootHash,
+			&i.SplitCommitmentRootValue,
 		); err != nil {
 			return nil, err
 		}

--- a/tarodb/sqlite/queries/assets.sql
+++ b/tarodb/sqlite/queries/assets.sql
@@ -252,7 +252,8 @@ SELECT
     genesis_info_view.prev_out AS genesis_prev_out,
     txns.raw_tx AS anchor_tx, txns.txid AS anchor_txid, txns.block_hash AS anchor_block_hash,
     utxos.outpoint AS anchor_outpoint,
-    utxo_internal_keys.raw_key AS anchor_internal_key
+    utxo_internal_keys.raw_key AS anchor_internal_key,
+    split_commitment_root_hash, split_commitment_root_value
 FROM assets
 JOIN genesis_info_view
     ON assets.genesis_id = genesis_info_view.gen_asset_id AND

--- a/tarofreighter/chain_porter.go
+++ b/tarofreighter/chain_porter.go
@@ -364,6 +364,13 @@ func (p *ChainPorter) waitForPkgConfirmation(pkg *OutboundParcelDelta) {
 		p.cfg.ErrChan <- mkErr("error encoding sender proof: %v", err)
 		return
 	}
+	newSenderProof := &proof.AnnotatedProof{
+		Locator: proof.Locator{
+			AssetID:   &pkg.AssetSpendDeltas[0].WitnessData[0].PrevID.ID,
+			ScriptKey: *senderProofSuffix.Asset.ScriptKey.PubKey,
+		},
+		Blob: updatedSenderProof.Bytes(),
+	}
 
 	// As a final step, we'll do the same for the receiver's proof as well.
 	var receiverProofSuffix proof.Proof
@@ -405,7 +412,9 @@ func (p *ChainPorter) waitForPkgConfirmation(pkg *OutboundParcelDelta) {
 		},
 		Blob: updatedReceiverProof.Bytes(),
 	}
-	err = p.cfg.AssetProofs.ImportProofs(ctx, receiverProof)
+	err = p.cfg.AssetProofs.ImportProofs(
+		ctx, receiverProof, newSenderProof,
+	)
 	if err != nil {
 		p.cfg.ErrChan <- mkErr("error importing proof: %v", err)
 		return

--- a/taroscript/send.go
+++ b/taroscript/send.go
@@ -477,7 +477,11 @@ func CreateSpendCommitments(inputCommitment *commitment.TaroCommitment,
 	// Remove the spent Asset from the AssetCommitment of the sender.  Fail
 	// if the input AssetCommitment or Asset were not in the input
 	// TaroCommitment.
-	inputCommitments := inputCommitment.Commitments()
+	inputCommitmentCopy, err := inputCommitment.Copy()
+	if err != nil {
+		return nil, err
+	}
+	inputCommitments := inputCommitmentCopy.Commitments()
 	senderCommitment, ok := inputCommitments[inputAsset.TaroCommitmentKey()]
 	if !ok {
 		return nil, ErrMissingAssetCommitment
@@ -554,7 +558,7 @@ func CreateSpendCommitments(inputCommitment *commitment.TaroCommitment,
 	// TODO(jhb): Add emptiness check for senderCommitment, to prune the
 	// AssetCommitment entirely when possible.
 	senderTaroCommitment := *inputCommitment
-	err := senderTaroCommitment.Update(senderCommitment, false)
+	err = senderTaroCommitment.Update(senderCommitment, false)
 	if err != nil {
 		return nil, err
 	}

--- a/taroscript/send_test.go
+++ b/taroscript/send_test.go
@@ -1228,7 +1228,7 @@ var createSpendOutputsTestCases = []createSpendOutputsTestCase{
 		err: taroscript.ErrMissingTaroCommitment,
 	},
 	{
-		name: "missing receciver commitment",
+		name: "missing receiver commitment",
 		f: func(t *testing.T) error {
 			state := initSpendScenario(t)
 			spend := taroscript.SpendDelta{


### PR DESCRIPTION
With the itest added in this diff, the tests fail for two reasons:
  1. The split commitment root wasn't properly being read from disk.
  2. The input asset is being mutated somewhere, so when we went to compute the _old_ root to place the PSBT information, it was already using the new amount/witness, etc, etc.

This commit is a temp workaround to demonstrate that something is being mutated here. By caching the pkScript+root, we capture it as it was read from disk.

Will remove this from draft once I add a proper fix for the mutation (in the send delta pipeline). 

This fixes an issue that would prevent an asset output from properly being spent again after a series of sends that each required a new split. 