### PR TITLE
multi: support non-interactive full-value sends

### DIFF
--- a/commitment/commitment_test.go
+++ b/commitment/commitment_test.go
@@ -586,6 +586,118 @@ func TestSplitCommitment(t *testing.T) {
 			},
 			err: ErrInvalidSplitLocator,
 		},
+		{
+			name: "unspendable root locator with non-zero amount",
+			f: func() (*asset.Asset, *SplitLocator, []*SplitLocator) {
+				input := randAsset(
+					t, genesisNormal, familyKeyNormal,
+				)
+				input.Amount = 3
+
+				root := &SplitLocator{
+					OutputIndex: 0,
+					AssetID:     genesisNormal.ID(),
+					ScriptKey:   asset.NUMSCompressedKey,
+					Amount:      1,
+				}
+				external := []*SplitLocator{{
+					OutputIndex: 1,
+					AssetID:     genesisNormal.ID(),
+					ScriptKey: asset.ToSerialized(
+						randKey(t).PubKey(),
+					),
+					Amount: 2,
+				}}
+
+				return input, root, external
+			},
+			err: ErrNonZeroSplitAmount,
+		},
+		{
+			name: "invalid zero-value root locator",
+			f: func() (*asset.Asset, *SplitLocator, []*SplitLocator) {
+				input := randAsset(
+					t, genesisNormal, familyKeyNormal,
+				)
+				input.Amount = 3
+
+				root := &SplitLocator{
+					OutputIndex: 0,
+					AssetID:     genesisNormal.ID(),
+					ScriptKey: asset.ToSerialized(
+						input.ScriptKey.PubKey,
+					),
+					Amount: 0,
+				}
+				external := []*SplitLocator{{
+					OutputIndex: 1,
+					AssetID:     genesisNormal.ID(),
+					ScriptKey: asset.ToSerialized(
+						randKey(t).PubKey(),
+					),
+					Amount: 3,
+				}}
+
+				return input, root, external
+			},
+			err: ErrInvalidScriptKey,
+		},
+		{
+			name: "zero-value external locator",
+			f: func() (*asset.Asset, *SplitLocator, []*SplitLocator) {
+				input := randAsset(
+					t, genesisNormal, familyKeyNormal,
+				)
+				input.Amount = 3
+
+				root := &SplitLocator{
+					OutputIndex: 0,
+					AssetID:     genesisNormal.ID(),
+					ScriptKey: asset.ToSerialized(
+						input.ScriptKey.PubKey,
+					),
+					Amount: 3,
+				}
+				external := []*SplitLocator{{
+					OutputIndex: 1,
+					AssetID:     genesisNormal.ID(),
+					ScriptKey: asset.ToSerialized(
+						randKey(t).PubKey(),
+					),
+					Amount: 0,
+				}}
+
+				return input, root, external
+			},
+			err: ErrZeroSplitAmount,
+		},
+		{
+			name: "full value split commitment",
+			f: func() (*asset.Asset, *SplitLocator, []*SplitLocator) {
+				input := randAsset(
+					t, genesisNormal, familyKeyNormal,
+				)
+				input.Amount = 3
+
+				root := &SplitLocator{
+					OutputIndex: 0,
+					AssetID:     genesisNormal.ID(),
+					ScriptKey:   asset.NUMSCompressedKey,
+					Amount:      0,
+				}
+				external := []*SplitLocator{{
+					OutputIndex: 1,
+					AssetID:     genesisNormal.ID(),
+					ScriptKey: asset.ToSerialized(
+						randKey(t).PubKey(),
+					),
+					Amount: 3,
+				}}
+
+				return input, root, external
+			},
+			err: nil,
+		},
 	}
 
 	for _, testCase := range testCases {

--- a/commitment/split.go
+++ b/commitment/split.go
@@ -34,6 +34,24 @@ var (
 	ErrInvalidSplitLocator = errors.New(
 		"at least one locator should be specified",
 	)
+
+	// ErrInvalidScriptKey is an error returned when a root locator has zero
+	// value but does not use the correct unspendable script key.
+	ErrInvalidScriptKey = errors.New(
+		"invalid script key for zero-amount locator",
+	)
+
+	// ErrZeroSplitAmount is an error returned when a non-root split locator
+	// has zero amount.
+	ErrZeroSplitAmount = errors.New(
+		"split locator has zero amount",
+	)
+
+	// ErrNonZeroSplitAmount is an error returned when a root locator uses
+	// an unspendable script key but has a non-zero amount.
+	ErrNonZeroSplitAmount = errors.New(
+		"unspendable root locator has non-zero amount",
+	)
 )
 
 // SplitLocator encodes the data that uniquely identifies an asset split within
@@ -133,6 +151,20 @@ func NewSplitCommitment(input *asset.Asset, outPoint wire.OutPoint,
 		return nil, ErrInvalidSplitLocator
 	}
 
+	// The only valid unspendable root locator uses the correct unspendable
+	// script key and has zero value.
+	if rootLocator.Amount == 0 &&
+		rootLocator.ScriptKey != asset.NUMSCompressedKey {
+
+		return nil, ErrInvalidScriptKey
+	}
+
+	if rootLocator.Amount != 0 &&
+		rootLocator.ScriptKey == asset.NUMSCompressedKey {
+
+		return nil, ErrNonZeroSplitAmount
+	}
+
 	// Map each SplitLocator to an asset split, making sure to decrement
 	// each split's amount from the asset input to ensure we fully consume
 	// the total input amount.
@@ -141,6 +173,7 @@ func NewSplitCommitment(input *asset.Asset, outPoint wire.OutPoint,
 	splitAssets := make(SplitSet, len(locators))
 	splitTree := mssmt.NewCompactedTree(mssmt.NewDefaultStore())
 	remainingAmount := input.Amount
+	rootIdx := len(locators) - 1
 	addAssetSplit := func(locator *SplitLocator) error {
 		// Return an error if we've already seen a locator with this
 		// output index.
@@ -190,7 +223,11 @@ func NewSplitCommitment(input *asset.Asset, outPoint wire.OutPoint,
 
 		return nil
 	}
-	for _, locator := range locators {
+	for idx, locator := range locators {
+		if idx != rootIdx && locator.Amount == 0 {
+			return nil, ErrZeroSplitAmount
+		}
+
 		if err := addAssetSplit(locator); err != nil {
 			return nil, err
 		}

--- a/itest/full_value_split_test.go
+++ b/itest/full_value_split_test.go
@@ -1,0 +1,89 @@
+package itest
+
+import (
+	"context"
+
+	"github.com/lightninglabs/taro/tarorpc"
+	"github.com/stretchr/testify/require"
+)
+
+// testFullValueSend tests that we can properly send the full value of a
+// normal asset.
+func testFullValueSend(t *harnessTest) {
+	// First, we'll make an normal assets with enough units to allow us to
+	// send it around a few times.
+	rpcAssets := mintAssetsConfirmBatch(
+		t, t.tarod, []*tarorpc.MintAssetRequest{simpleAssets[0]},
+	)
+
+	genInfo := rpcAssets[0].AssetGenesis
+	genBootstrap := rpcAssets[0].AssetGenesis.GenesisBootstrapInfo
+
+	ctxb := context.Background()
+
+	// Now that we have the asset created, we'll make a new node that'll
+	// serve as the node which'll receive the assets.
+	secondTarod := setupTarodHarness(
+		t.t, t, t.lndHarness.BackendCfg, t.lndHarness.Bob, t.universeServer,
+	)
+	defer func() {
+		require.NoError(t.t, secondTarod.stop(true))
+	}()
+
+	// Next, we'll attempt to complete three transfers of the full value of
+	// the asset between our main node and Bob.
+	var (
+		numSends     = 3
+		fullAmount   = rpcAssets[0].Amount
+		receiverAddr *tarorpc.Addr
+		err          error
+	)
+
+	for i := 0; i < numSends; i++ {
+		// Create an address for the receiver and send the asset. We
+		// start with Bob receiving the asset, then sending it back
+		// to the main node, and so on.
+		if i%2 == 0 {
+			receiverAddr, err = secondTarod.NewAddr(
+				ctxb, &tarorpc.NewAddrRequest{
+					GenesisBootstrapInfo: genBootstrap,
+					Amt:                  fullAmount,
+				},
+			)
+			require.NoError(t.t, err)
+
+			assertAddrCreated(
+				t.t, secondTarod, rpcAssets[0], receiverAddr,
+			)
+			_ = sendAssetsToAddr(t, t.tarod, receiverAddr)
+			confirmSend(
+				t, t.tarod, secondTarod, receiverAddr, genInfo,
+			)
+		} else {
+			receiverAddr, err = t.tarod.NewAddr(
+				ctxb, &tarorpc.NewAddrRequest{
+					GenesisBootstrapInfo: genBootstrap,
+					Amt:                  fullAmount,
+				},
+			)
+			require.NoError(t.t, err)
+
+			assertAddrCreated(
+				t.t, t.tarod, rpcAssets[0], receiverAddr,
+			)
+			_ = sendAssetsToAddr(t, secondTarod, receiverAddr)
+			confirmSend(
+				t, secondTarod, t.tarod, receiverAddr, genInfo,
+			)
+		}
+	}
+
+	// Check the final state of both nodes. The main node should list 2
+	// zero-value transfers. and Bob should have 1. The main node should
+	// show a balance of zero, and Bob should hold the total asset supply.
+	assertTransfers(t.t, t.tarod, []int64{0, 0})
+	assertBalance(t.t, t.tarod, genInfo.AssetId, int64(0))
+
+	assertTransfers(t.t, secondTarod, []int64{0})
+	assertBalance(t.t, secondTarod, genInfo.AssetId, int64(fullAmount))
+}

--- a/itest/test_list_on_test.go
+++ b/itest/test_list_on_test.go
@@ -20,4 +20,8 @@ var testCases = []*testCase{
 		name: "round trip send",
 		test: testRoundTripSend,
 	},
+	{
+		name: "full value send",
+		test: testFullValueSend,
+	},
 }

--- a/tarodb/sqlite/migrations/000002_assets.up.sql
+++ b/tarodb/sqlite/migrations/000002_assets.up.sql
@@ -172,7 +172,7 @@ CREATE TABLE IF NOT EXISTS assets (
 
     anchor_utxo_id INTEGER REFERENCES managed_utxos(utxo_id),
     
-    UNIQUE(genesis_id, script_key_id)
+    UNIQUE(asset_id, genesis_id, script_key_id)
 );
 
 -- asset_witnesses stores the set of input witnesses for the latest state of an

--- a/vm/error.go
+++ b/vm/error.go
@@ -57,6 +57,10 @@ const (
 	// ErrInvalidSplitCommitmentProof represents an error case where an
 	// asset split has an invalid split commitment proof.
 	ErrInvalidSplitCommitmentProof
+
+	// ErrInvalidRootAsset represents an error case where the root asset
+	// of an asset split has zero value but a spendable script key.
+	ErrInvalidRootAsset
 )
 
 // Wrap select errors related to virtual TX handling to provide more
@@ -99,6 +103,8 @@ func (k ErrorKind) String() string {
 		return "invalid split commitment asset witness"
 	case ErrInvalidSplitCommitmentProof:
 		return "invalid split commitment proof"
+	case ErrInvalidRootAsset:
+		return "invalid zero-value root asset"
 	default:
 		return "unknown"
 	}

--- a/vm/vm.go
+++ b/vm/vm.go
@@ -145,6 +145,19 @@ func (vm *Engine) validateSplit() error {
 		return err
 	}
 
+	// If the split requires a zero-value root asset, the root asset must
+	// be unspendable. Non-inflation of the split is enforced elsewhere, at
+	// the end of vm.Execute().
+	if vm.newAsset.Amount == 0 && !vm.newAsset.IsUnspendable() {
+		return newErrKind(ErrInvalidRootAsset)
+	}
+
+	// If we are validating the root asset of the split, the root split must
+	// also be unspendable.
+	if vm.splitAsset.Amount == 0 && !vm.splitAsset.IsUnspendable() {
+		return newErrKind(ErrInvalidRootAsset)
+	}
+
 	// Finally, verify that the split commitment proof for the split asset
 	// resolves to the split commitment root found within the change asset.
 	locator := &commitment.SplitLocator{


### PR DESCRIPTION
Addresses #99 and #121. Collectible support will likely be a follow-up PR.

Support full-value splits (no change for sender) via split commitments by defining a NUMs / unspendable key, and requiring that key for zero-value root splits.

TODOs:

- [x] Update split creation and tests
- [x] Update VM to validate the root for a full-value split
- [x] Update send utils to create full-value splits
- [x] Update tarofreighter to create full-value splits
- [x] Add full-value split case to itests