### PR TITLE
docs: clarify the necessary build tags for lnd in README/Prerequisites

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,13 @@ Custody of Taro assets is segmented across LND and Taro to maximize security. LN
 
 ## Prerequisites:
 
-Taro requires [LND](https://github.com/lightningnetwork/lnd/) (compiled on the latest `master` branch) to be synced and running on the same Bitcoin network as Taro (e.g. regtest, simnet, testnet3). RPC connections need to be accepted and a [valid macaroon](https://docs.lightning.engineering/lightning-network-tools/lnd/macaroons) needs to be present.
+Taro requires [LND](https://github.com/lightningnetwork/lnd/) (compiled on the latest `master` branch with the relevant tags, see below) to be synced and running on the same Bitcoin network as Taro (e.g. regtest, simnet, testnet3). RPC connections need to be accepted and a [valid macaroon](https://docs.lightning.engineering/lightning-network-tools/lnd/macaroons) needs to be present.
+
+```shell
+🍠 git clone https://github.com/lightningnetwork/lnd.git
+🍠 cd lnd 
+🍠 make install tags="signrpc walletrpc chainrpc invoicesrpc"
+```
  
 ## Installation:
 


### PR DESCRIPTION
we require to build lnd with `tags=signrpc walletrpc chainrpc invoicesrpc` same as in the "Getting started" Guide

without the explicit build tags taro failed to connect to lnd
``` 
2022-09-29 20:04:09.162 [INF] CONF: Attempting to establish connection to lnd...
error creating server: unable to connect to lnd node: error checking connected lnd version. at least version "v0.15.99, build tags 'signrpc,walletrpc,chainrpc,invoicesrpc'" is required
```