### PR TITLE
Wrap math.MaxInt64 in int64() for 32-bit cross-compilation

### DIFF
--- a/cmd/tarocli/addrs.go
+++ b/cmd/tarocli/addrs.go
@@ -141,7 +141,8 @@ func queryAddr(ctx *cli.Context) error {
 		start = startTime.Unix()
 	}
 
-	end := int64(math.MaxInt64) //wrap so MaxInt64 will cross-compile on 32 bit arch
+	// Wrap with int64() so math.MaxInt64 will cross-compile on 32-bit arch.
+	end := int64(math.MaxInt64) 
 	if ctx.IsSet(createdBeforeName) {
 		endOffset, err := time.ParseDuration(ctx.String(createdBeforeName))
 		if err != nil {

--- a/cmd/tarocli/addrs.go
+++ b/cmd/tarocli/addrs.go
@@ -141,7 +141,7 @@ func queryAddr(ctx *cli.Context) error {
 		start = startTime.Unix()
 	}
 
-	end := math.MaxInt64
+	end := int64(math.MaxInt64) //wrap so MaxInt64 will cross-compile on 32 bit arch
 	if ctx.IsSet(createdBeforeName) {
 		endOffset, err := time.ParseDuration(ctx.String(createdBeforeName))
 		if err != nil {

--- a/tarodb/addrs.go
+++ b/tarodb/addrs.go
@@ -272,7 +272,7 @@ func (t *TaroAddressBook) QueryAddrs(ctx context.Context,
 	// If the created before time is zero, then we'll use a very large date
 	// to ensure that we don't restrict based on this field.
 	if params.CreatedBefore.IsZero() {
-		params.CreatedBefore = time.Unix(math.MaxInt64, 0)
+		params.CreatedBefore = time.Unix(int64(math.MaxInt64), 0)
 	}
 
 	// Similarly, for sqlite using LIMIT with a value of -1 means no rows


### PR DESCRIPTION
We must wrap `math.MaxInt64` calls in `int64()` for rpi/arm/32-bit support, otherwise cross-compilation yields this error:

`cmd/tarocli/addrs.go:144:9: cannot use math.MaxInt64 (untyped int constant 9223372036854775807) as int value in assignment (overflows)`