### PR TITLE
SendAsset: Correct receiver output index

### DIFF
--- a/tarofreighter/parcel.go
+++ b/tarofreighter/parcel.go
@@ -501,6 +501,10 @@ func (s *sendPackage) deliverResponse(respChan chan<- *PendingParcel) {
 		"notification", s.ReceiverAddr.ID(),
 		s.ReceiverAddr.ScriptKey.SerializeCompressed())
 
+	// Get the output index of the receiver from the spend locators.
+	receiverStateKey := s.ReceiverAddr.AssetCommitmentKey()
+	receiverIndex := s.SendDelta.Locators[receiverStateKey].OutputIndex
+
 	respChan <- &PendingParcel{
 		NewAnchorPoint: s.OutboundPkg.NewAnchorPoint,
 		TransferTx:     s.OutboundPkg.AnchorTx,
@@ -532,8 +536,11 @@ func (s *sendPackage) deliverResponse(respChan chan<- *PendingParcel) {
 			{
 				AssetInput: AssetInput{
 					PrevID: asset.PrevID{
-						OutPoint: s.OutboundPkg.NewAnchorPoint,
-						ID:       s.ReceiverAddr.ID(),
+						OutPoint: wire.OutPoint{
+							Hash:  s.OutboundPkg.NewAnchorPoint.Hash,
+							Index: receiverIndex,
+						},
+						ID: s.ReceiverAddr.ID(),
 						ScriptKey: asset.ToSerialized(
 							&s.ReceiverAddr.ScriptKey,
 						),


### PR DESCRIPTION
The [output](https://docs.lightning.engineering/lightning-network-tools/taro/first-steps#docs-internal-guid-90fc9698-7fff-dc82-4d66-091df08c58a9) from `tarocli assets send` currently has a mistake: 

```
 "new_outputs": [
            {
                "anchor_point": "96a370af09f4ed97f408a9a497df2d7a5b0b53cafba7b23654062307cebc3163:0",
                "asset_id": "33644efe039d3569e6bafb07bc8f5959578a909e9c5e1c15949c986c54edbf35",
                "script_key": "028055056a70daf83e654a28b640dbf7fa893953f87398a51b7c2021520402a54b",
                "amount": "900",
                "new_proof_blob": null,
                "split_commit_proof": null
            },
            {
                "anchor_point": "96a370af09f4ed97f408a9a497df2d7a5b0b53cafba7b23654062307cebc3163:0",
                "asset_id": "33644efe039d3569e6bafb07bc8f5959578a909e9c5e1c15949c986c54edbf35",
                "script_key": "028055056a70daf83e654a28b640dbf7fa893953f87398a51b7c2021520402a54b",
                "amount": "100",
                "new_proof_blob": null,
                "split_commit_proof": null
            }
        ]
``` 

The new `anchor_point` for the sender and the receiver should have different indices (script key should be different as well, but that is already [fixed in master](https://github.com/lightninglabs/taro/commit/f935c5bf78a4322cf8465e2a6da97d5533905dc0)).

In this PR we locate the index of the receiver from the `SpendLocator` and set it accordingly.