### PR TITLE
multi: fix input pkscript construction, add round trip spend test

### DIFF
--- a/itest/addrs_test.go
+++ b/itest/addrs_test.go
@@ -39,11 +39,12 @@ func testAddresses(t *harnessTest) {
 
 	// We'll make a second node now that'll be the receiver of all the
 	// assets made above.
-	bob := t.lndHarness.NewNode(t.t, "bob", lndDefaultArgs)
 	secondTarod := setupTarodHarness(
-		t.t, t, t.lndHarness.BackendCfg, bob, t.universeServer,
+		t.t, t, t.lndHarness.BackendCfg, t.lndHarness.Bob, t.universeServer,
 	)
-	defer shutdownAndAssert(t, bob, secondTarod)
+	defer func() {
+		require.NoError(t.t, secondTarod.stop(true))
+	}()
 
 	var (
 		addresses []*tarorpc.Addr

--- a/itest/round_trip_send_test.go
+++ b/itest/round_trip_send_test.go
@@ -1,0 +1,91 @@
+package itest
+
+import (
+	"context"
+
+	"github.com/lightninglabs/taro/tarorpc"
+	"github.com/lightningnetwork/lnd/lntest/wait"
+	"github.com/stretchr/testify/require"
+)
+
+// testRoundTripSend tests that we can properly send the full value of a
+// normal asset.
+func testRoundTripSend(t *harnessTest) {
+	// First, we'll make an normal assets with enough units to allow us to
+	// send it around a few times.
+	rpcAssets := mintAssetsConfirmBatch(
+		t, t.tarod, []*tarorpc.MintAssetRequest{simpleAssets[0]},
+	)
+
+	genInfo := rpcAssets[0].AssetGenesis
+	genBootstrap := rpcAssets[0].AssetGenesis.GenesisBootstrapInfo
+
+	ctxb := context.Background()
+
+	// Now that we have the asset created, we'll make a new node that'll
+	// serve as the node which'll receive the assets.
+	secondTarod := setupTarodHarness(
+		t.t, t, t.lndHarness.BackendCfg, t.lndHarness.Bob, t.universeServer,
+	)
+	defer func() {
+		require.NoError(t.t, secondTarod.stop(true))
+	}()
+
+	// We'll send half of the minted units to Bob, and then have Bob return
+	// half of the units he received.
+	fullAmt := rpcAssets[0].Amount
+	bobAmt := fullAmt / 2
+	aliceAmt := bobAmt / 2
+
+	// First, we'll send half of the units to Bob.
+	bobAddr, err := secondTarod.NewAddr(ctxb, &tarorpc.NewAddrRequest{
+		GenesisBootstrapInfo: genBootstrap,
+		Amt:                  bobAmt,
+	})
+	require.NoError(t.t, err)
+
+	assertAddrCreated(t.t, secondTarod, rpcAssets[0], bobAddr)
+	sendResp := sendAssetsToAddr(t, t.tarod, bobAddr)
+	sendRespJSON, err := formatProtoJSON(sendResp)
+	require.NoError(t.t, err)
+	t.Logf("Got response from sending assets: %v", sendRespJSON)
+
+	confirmSend(t, t.tarod, secondTarod, bobAddr, genInfo)
+
+	// Now, Alice will request half of the assets she sent to Bob.
+	aliceAddr, err := t.tarod.NewAddr(ctxb, &tarorpc.NewAddrRequest{
+		GenesisBootstrapInfo: genBootstrap,
+		Amt:                  aliceAmt,
+	})
+	require.NoError(t.t, err)
+
+	assertAddrCreated(t.t, t.tarod, rpcAssets[0], aliceAddr)
+	sendResp = sendAssetsToAddr(t, secondTarod, aliceAddr)
+	sendRespJSON, err = formatProtoJSON(sendResp)
+	require.NoError(t.t, err)
+	t.Logf("Got response from sending assets: %v", sendRespJSON)
+
+	confirmSend(t, secondTarod, t.tarod, aliceAddr, genInfo)
+
+	// Check the final state of both nodes. Each node should list
+	// one transfer, and Alice should have 3/4 of the total units.
+	err = wait.NoError(func() error {
+		assertTransfers(t.t, t.tarod, []int64{bobAmt})
+		assertBalance(t.t, t.tarod, genInfo.AssetId, bobAmt+aliceAmt)
+
+		assertTransfers(t.t, secondTarod, []int64{aliceAmt})
+		assertBalance(t.t, secondTarod, genInfo.AssetId, aliceAmt)
+
+		return nil
+	}, defaultTimeout/2)
+	require.NoError(t.t, err)
+}
+
+// confirmSend mines a new block and passes proofs for the asset transfer
+// between the sender and receiver,
+func confirmSend(t *harnessTest, src, dst *tarodHarness, rpcAddr *tarorpc.Addr,
+	genInfo *tarorpc.GenesisInfo) {
+
+	_ = mineBlocks(t, t.lndHarness, 1, 1)
+	_ = sendProof(t, src, dst, rpcAddr, genInfo)
+}

--- a/itest/send_test.go
+++ b/itest/send_test.go
@@ -53,7 +53,7 @@ func testBasicSend(t *harnessTest) {
 
 		assertAddrCreated(t.t, secondTarod, rpcAssets[0], bobAddr)
 
-		sendResp := sendAssetsToAddr(t, bobAddr)
+		sendResp := sendAssetsToAddr(t, t.tarod, bobAddr)
 
 		// Check that we now have two new outputs, and that they differ
 		// in outpoints and scripts.

--- a/itest/test_list_on_test.go
+++ b/itest/test_list_on_test.go
@@ -16,4 +16,8 @@ var testCases = []*testCase{
 		name: "basic send",
 		test: testBasicSend,
 	},
+	{
+		name: "round trip send",
+		test: testRoundTripSend,
+	},
 }

--- a/tarofreighter/parcel.go
+++ b/tarofreighter/parcel.go
@@ -200,7 +200,43 @@ type sendPackage struct {
 // anchor output as well as the Taro script root of the output (the Taproot
 // tweak).
 func (s *sendPackage) inputAnchorPkScript() ([]byte, []byte, error) {
-	taroScriptRoot := s.InputAsset.Commitment.TapscriptRoot(nil)
+	// If the input asset was received non-interactively, then the Taro tree
+	// of the input anchor output was built with asset leaves that had empty
+	// SplitCommitments. However, the SplitCommitment field was
+	// populated when the transfer of the input asset was verified.
+	// To recompute the correct output script, we need to build a Taro tree
+	// from the input asset without any SplitCommitment.
+	inputAssetCopy := s.InputAsset.Asset.Copy()
+	inputAnchorCommitmentCopy, err := s.InputAsset.Commitment.Copy()
+	if err != nil {
+		return nil, nil, err
+	}
+
+	// Assets received via non-interactive split should have one witness,
+	// with an empty PrevID and a SplitCommitment present.
+	if inputAssetCopy.HasSplitCommitmentWitness() &&
+		*inputAssetCopy.PrevWitnesses[0].PrevID == asset.ZeroPrevID {
+
+		inputAssetCopy.PrevWitnesses[0].SplitCommitment = nil
+
+		// Build the new Taro tree by first updating the asset
+		// commitment tree with the new asset leaf, and then the
+		// top-level Taro tree.
+		inputCommitments := inputAnchorCommitmentCopy.Commitments()
+		inputCommitmentKey := inputAssetCopy.TaroCommitmentKey()
+		inputAssetTree := inputCommitments[inputCommitmentKey]
+		err = inputAssetTree.Update(inputAssetCopy, false)
+		if err != nil {
+			return nil, nil, err
+		}
+
+		err = inputAnchorCommitmentCopy.Update(inputAssetTree, false)
+		if err != nil {
+			return nil, nil, err
+		}
+	}
+
+	taroScriptRoot := inputAnchorCommitmentCopy.TapscriptRoot(nil)
 
 	anchorPubKey := txscript.ComputeTaprootOutputKey(
 		s.InputAsset.InternalKey.PubKey, taroScriptRoot[:],

--- a/taroscript/send.go
+++ b/taroscript/send.go
@@ -182,7 +182,7 @@ func CreateTemplatePsbt(locators SpendLocators) (*psbt.Packet, error) {
 		maxOutputIndex++
 	}
 
-	txTemplate := wire.NewMsgTx(int32(maxOutputIndex))
+	txTemplate := wire.NewMsgTx(2)
 	for i := uint32(0); i < maxOutputIndex; i++ {
 		txTemplate.AddTxOut(createDummyOutput())
 	}
@@ -562,7 +562,7 @@ func CreateSpendCommitments(inputCommitment *commitment.TaroCommitment,
 	//
 	// TODO(jhb): Add emptiness check for senderCommitment, to prune the
 	// AssetCommitment entirely when possible.
-	senderTaroCommitment := *inputCommitment
+	senderTaroCommitment := *inputCommitmentCopy
 	err = senderTaroCommitment.Update(senderCommitment, false)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Spun off of #159.

Fixes multiple issues that caused round-trip (minter->receiver->minter) spends to fail:

1. The input TaroCommitment tree was being mutated when computing new TaroCommitments.
2. The input TaroCommitment tree includes asset leaves with SplitCommitments populated, which does not match the tree used for the actual transfer TX.

For the receiver to spend back to the minter, they need to recompute the pkScript used in the anchor output. Both of these issues caused the pkScript to be computed incorrectly in `inputAnchorPkScript()`. The mismatched pkScript caused transaction broadcast to fail.

The new itest includes a round-trip spend to test this fix.