### PR TITLE
taroscript: add add more error context to IsValidInput

### DIFF
--- a/taroscript/send.go
+++ b/taroscript/send.go
@@ -246,7 +246,9 @@ func IsValidInput(input *commitment.TaroCommitment,
 	inputCommitments := input.Commitments()
 	assetCommitment, ok := inputCommitments[addr.TaroCommitmentKey()]
 	if !ok {
-		return nil, needsSplit, ErrMissingInputAsset
+		return nil, needsSplit, fmt.Errorf("input commitment does "+
+			"not contain asset_id=%x: %w", addr.TaroCommitmentKey(),
+			ErrMissingInputAsset)
 	}
 
 	// The asset tree must have a non-empty Asset at the location
@@ -260,7 +262,10 @@ func IsValidInput(input *commitment.TaroCommitment,
 	}
 
 	if inputAsset == nil {
-		return nil, needsSplit, ErrMissingInputAsset
+		return nil, needsSplit, fmt.Errorf("input commitment does not "+
+			"contain leaf with script_key=%x: %w",
+			inputScriptKey.SerializeCompressed(),
+			ErrMissingInputAsset)
 	}
 
 	// For Normal assets, we also check that the input asset amount is


### PR DESCRIPTION
In this commit, we add a bit more detail to an error case in
`IsValidInput`. With this change, we should now get distinct log
messages if the top level commitment isn't found vs the inner commitment
leaf.