### PR TITLE
multi: support non-interactive collectible sends

### DIFF
--- a/commitment/commitment_test.go
+++ b/commitment/commitment_test.go
@@ -464,7 +464,7 @@ func TestSplitCommitment(t *testing.T) {
 		err  error
 	}{
 		{
-			name: "invalid asset input type",
+			name: "collectible split with excess external locators",
 			f: func() (*asset.Asset, *SplitLocator, []*SplitLocator) {
 				input := randAsset(
 					t, genesisCollectible,
@@ -473,14 +473,52 @@ func TestSplitCommitment(t *testing.T) {
 				root := &SplitLocator{
 					OutputIndex: 0,
 					AssetID:     genesisCollectible.ID(),
+					ScriptKey:   asset.NUMSCompressedKey,
+					Amount:      0,
+				}
+				external := []*SplitLocator{{
+					OutputIndex: 1,
+					AssetID:     genesisCollectible.ID(),
 					ScriptKey: asset.ToSerialized(
-						input.ScriptKey.PubKey,
+						randKey(t).PubKey(),
 					),
 					Amount: input.Amount,
-				}
-				return input, root, nil
+				}, {
+					OutputIndex: 1,
+					AssetID:     genesisCollectible.ID(),
+					ScriptKey: asset.ToSerialized(
+						randKey(t).PubKey(),
+					),
+					Amount: input.Amount,
+				}}
+				return input, root, external
 			},
-			err: ErrInvalidInputType,
+			err: ErrInvalidSplitLocatorCount,
+		},
+		{
+			name: "collectible split commitment",
+			f: func() (*asset.Asset, *SplitLocator, []*SplitLocator) {
+				input := randAsset(
+					t, genesisCollectible,
+					familyKeyCollectible,
+				)
+				root := &SplitLocator{
+					OutputIndex: 0,
+					AssetID:     genesisCollectible.ID(),
+					ScriptKey:   asset.NUMSCompressedKey,
+					Amount:      0,
+				}
+				external := []*SplitLocator{{
+					OutputIndex: 1,
+					AssetID:     genesisCollectible.ID(),
+					ScriptKey: asset.ToSerialized(
+						randKey(t).PubKey(),
+					),
+					Amount: input.Amount,
+				}}
+				return input, root, external
+			},
+			err: nil,
 		},
 		{
 			name: "locator duplicate output index",

--- a/itest/collectible_split_test.go
+++ b/itest/collectible_split_test.go
@@ -1,0 +1,91 @@
+package itest
+
+import (
+	"context"
+
+	"github.com/lightninglabs/taro/tarorpc"
+	"github.com/stretchr/testify/require"
+)
+
+// testCollectibleSend tests that we can properly send a collectible asset
+// with split commitments.
+func testCollectibleSend(t *harnessTest) {
+	// First, we'll make a collectible with emission enabled.
+	rpcAssets := mintAssetsConfirmBatch(
+		t, t.tarod, []*tarorpc.MintAssetRequest{issuableAssets[1]},
+	)
+
+	familyKey := rpcAssets[0].AssetFamily.TweakedFamilyKey
+	genInfo := rpcAssets[0].AssetGenesis
+	genBootstrap := rpcAssets[0].AssetGenesis.GenesisBootstrapInfo
+
+	ctxb := context.Background()
+
+	// Now that we have the asset created, we'll make a new node that'll
+	// serve as the node which'll receive the assets.
+	secondTarod := setupTarodHarness(
+		t.t, t, t.lndHarness.BackendCfg, t.lndHarness.Bob, t.universeServer,
+	)
+	defer func() {
+		require.NoError(t.t, secondTarod.stop(true))
+	}()
+
+	// Next, we'll attempt to complete three transfers of the full value of
+	// the asset between our main node and Bob.
+	var (
+		numSends     = 3
+		fullAmount   = rpcAssets[0].Amount
+		receiverAddr *tarorpc.Addr
+		err          error
+	)
+
+	for i := 0; i < numSends; i++ {
+		// Create an address for the receiver and send the asset. We
+		// start with Bob receiving the asset, then sending it back
+		// to the main node, and so on.
+		if i%2 == 0 {
+			receiverAddr, err = secondTarod.NewAddr(
+				ctxb, &tarorpc.NewAddrRequest{
+					GenesisBootstrapInfo: genBootstrap,
+					FamKey:               familyKey,
+					Amt:                  fullAmount,
+				},
+			)
+			require.NoError(t.t, err)
+
+			assertAddrCreated(
+				t.t, secondTarod, rpcAssets[0], receiverAddr,
+			)
+			_ = sendAssetsToAddr(t, t.tarod, receiverAddr)
+			confirmSend(
+				t, t.tarod, secondTarod, receiverAddr, genInfo,
+			)
+		} else {
+			receiverAddr, err = t.tarod.NewAddr(
+				ctxb, &tarorpc.NewAddrRequest{
+					GenesisBootstrapInfo: genBootstrap,
+					FamKey:               familyKey,
+					Amt:                  fullAmount,
+				},
+			)
+			require.NoError(t.t, err)
+
+			assertAddrCreated(
+				t.t, t.tarod, rpcAssets[0], receiverAddr,
+			)
+			_ = sendAssetsToAddr(t, secondTarod, receiverAddr)
+			confirmSend(
+				t, secondTarod, t.tarod, receiverAddr, genInfo,
+			)
+		}
+	}
+
+	// Check the final state of both nodes. The main node should list 2
+	// zero-value transfers. and Bob should have 1. The main node should
+	// show a balance of zero, and Bob should hold the total asset supply.
+	assertTransfers(t.t, t.tarod, []int64{0, 0})
+	assertBalance(t.t, t.tarod, genInfo.AssetId, int64(0))
+
+	assertTransfers(t.t, secondTarod, []int64{0})
+	assertBalance(t.t, secondTarod, genInfo.AssetId, int64(fullAmount))
+}

--- a/itest/test_list_on_test.go
+++ b/itest/test_list_on_test.go
@@ -24,4 +24,8 @@ var testCases = []*testCase{
 		name: "full value send",
 		test: testFullValueSend,
 	},
+	{
+		name: "collectible send",
+		test: testCollectibleSend,
+	},
 }

--- a/tarofreighter/chain_porter.go
+++ b/tarofreighter/chain_porter.go
@@ -600,6 +600,16 @@ func (p *ChainPorter) stateStep(currentPkg sendPackage) (*sendPackage, error) {
 		// to complete the send w/o merging inputs.
 		assetInput := elgigibleCommitments[0]
 
+		// If the key found for the input UTXO is not from the Taro
+		// keyfamily, something has gone wrong with the DB.
+		if assetInput.InternalKey.Family != tarogarden.TaroKeyFamily {
+			return nil, fmt.Errorf("invalid internal key family "+
+				"for selected input: %v %v",
+				assetInput.InternalKey.Family,
+				assetInput.InternalKey.Index,
+			)
+		}
+
 		// At this point, we have a valid "coin" to spend in the
 		// commitment, so we'll update the relevant information in the
 		// send package.

--- a/tarofreighter/chain_porter.go
+++ b/tarofreighter/chain_porter.go
@@ -636,8 +636,8 @@ func (p *ChainPorter) stateStep(currentPkg sendPackage) (*sendPackage, error) {
 
 		// We'll validate the selected input and commitment. From this
 		// we'll gain the asset that we'll use as an input and info
-		// w.r.t if we need to split or not.
-		inputAsset, needsSplit, err := taroscript.IsValidInput(
+		// w.r.t if we need to use an unspendable zero-value root.
+		inputAsset, fullValue, err := taroscript.IsValidInput(
 			currentPkg.InputAsset.Commitment, *currentPkg.ReceiverAddr,
 			*currentPkg.InputAsset.Asset.ScriptKey.PubKey,
 			*p.cfg.ChainParams,
@@ -665,9 +665,7 @@ func (p *ChainPorter) stateStep(currentPkg sendPackage) (*sendPackage, error) {
 		// If we are sending the full value of the input asset, or
 		// sending a collectible, we will need to create a split with
 		// unspendable change.
-		if (inputAsset.Type == asset.Normal && !needsSplit) ||
-			inputAsset.Type == asset.Collectible {
-
+		if fullValue {
 			currentPkg.SenderScriptKey = asset.NUMSScriptKey
 		} else {
 			senderScriptKey, err := p.cfg.KeyRing.DeriveNextKey(

--- a/taroscript/send.go
+++ b/taroscript/send.go
@@ -328,8 +328,8 @@ func PrepareAssetSplitSpend(addr address.Taro, prevInput asset.PrevID,
 	updatedDelta.Locators[receiverStateKey] = receiverLocator
 
 	// Enforce an unspendable root split if the split sends the full value
-	// of the input asset.
-	if senderLocator.Amount == 0 &&
+	// of the input asset or if the split sends a collectible.
+	if (senderLocator.Amount == 0 || inputAsset.Type == asset.Collectible) &&
 		senderLocator.ScriptKey != asset.NUMSCompressedKey {
 
 		return nil, commitment.ErrInvalidScriptKey

--- a/taroscript/send_test.go
+++ b/taroscript/send_test.go
@@ -2136,11 +2136,11 @@ var addressValidInputTestCases = []addressValidInputTestCase{
 		name: "valid normal",
 		f: func(t *testing.T) (*asset.Asset, *asset.Asset, error) {
 			state := initSpendScenario(t)
-			inputAsset, needsSplit, err := taroscript.IsValidInput(
+			inputAsset, fullValue, err := taroscript.IsValidInput(
 				&state.asset1TaroTree, state.address1,
 				state.spenderScriptKey, address.MainNetTaro,
 			)
-			require.False(t, needsSplit)
+			require.True(t, fullValue)
 			return &state.asset1, inputAsset, err
 		},
 		err: nil,
@@ -2149,12 +2149,12 @@ var addressValidInputTestCases = []addressValidInputTestCase{
 		name: "valid collectible with family key",
 		f: func(t *testing.T) (*asset.Asset, *asset.Asset, error) {
 			state := initSpendScenario(t)
-			inputAsset, needsSplit, err := taroscript.IsValidInput(
+			inputAsset, fullValue, err := taroscript.IsValidInput(
 				&state.asset1CollectFamilyTaroTree,
 				state.address1CollectFamily,
 				state.spenderScriptKey, address.TestNet3Taro,
 			)
-			require.False(t, needsSplit)
+			require.True(t, fullValue)
 			return &state.asset1CollectFamily, inputAsset, err
 		},
 		err: nil,
@@ -2163,11 +2163,11 @@ var addressValidInputTestCases = []addressValidInputTestCase{
 		name: "valid asset split",
 		f: func(t *testing.T) (*asset.Asset, *asset.Asset, error) {
 			state := initSpendScenario(t)
-			inputAsset, needsSplit, err := taroscript.IsValidInput(
+			inputAsset, fullValue, err := taroscript.IsValidInput(
 				&state.asset2TaroTree, state.address1,
 				state.spenderScriptKey, address.MainNetTaro,
 			)
-			require.True(t, needsSplit)
+			require.False(t, fullValue)
 			return &state.asset2, inputAsset, err
 		},
 		err: nil,
@@ -2176,11 +2176,11 @@ var addressValidInputTestCases = []addressValidInputTestCase{
 		name: "normal with insufficient amount",
 		f: func(t *testing.T) (*asset.Asset, *asset.Asset, error) {
 			state := initSpendScenario(t)
-			inputAsset, needsSplit, err := taroscript.IsValidInput(
+			inputAsset, fullValue, err := taroscript.IsValidInput(
 				&state.asset1TaroTree, state.address2,
 				state.spenderScriptKey, address.MainNetTaro,
 			)
-			require.False(t, needsSplit)
+			require.False(t, fullValue)
 			return &state.asset1, inputAsset, err
 		},
 		err: taroscript.ErrInsufficientInputAsset,
@@ -2189,12 +2189,12 @@ var addressValidInputTestCases = []addressValidInputTestCase{
 		name: "collectible with missing input asset",
 		f: func(t *testing.T) (*asset.Asset, *asset.Asset, error) {
 			state := initSpendScenario(t)
-			inputAsset, needsSplit, err := taroscript.IsValidInput(
+			inputAsset, fullValue, err := taroscript.IsValidInput(
 				&state.asset1TaroTree,
 				state.address1CollectFamily,
 				state.spenderScriptKey, address.TestNet3Taro,
 			)
-			require.False(t, needsSplit)
+			require.False(t, fullValue)
 			return &state.asset1, inputAsset, err
 		},
 		err: taroscript.ErrMissingInputAsset,
@@ -2209,11 +2209,11 @@ var addressValidInputTestCases = []addressValidInputTestCase{
 				&address.TestNet3Taro,
 			)
 			require.NoError(t, err)
-			inputAsset, needsSplit, err := taroscript.IsValidInput(
+			inputAsset, fullValue, err := taroscript.IsValidInput(
 				&state.asset1TaroTree, *address1testnet,
 				state.receiverPubKey, address.TestNet3Taro,
 			)
-			require.False(t, needsSplit)
+			require.False(t, fullValue)
 			return &state.asset1, inputAsset, err
 		},
 		err: taroscript.ErrMissingInputAsset,
@@ -2228,11 +2228,11 @@ var addressValidInputTestCases = []addressValidInputTestCase{
 				&address.TestNet3Taro,
 			)
 			require.NoError(t, err)
-			inputAsset, needsSplit, err := taroscript.IsValidInput(
+			inputAsset, fullValue, err := taroscript.IsValidInput(
 				&state.asset1TaroTree, *address1testnet,
 				state.receiverPubKey, address.MainNetTaro,
 			)
-			require.False(t, needsSplit)
+			require.False(t, fullValue)
 			return &state.asset1, inputAsset, err
 		},
 		err: address.ErrMismatchedHRP,

--- a/vm/error.go
+++ b/vm/error.go
@@ -47,7 +47,7 @@ const (
 	ErrInvalidTransferWitness
 
 	// ErrInvalidSplitAssetType represents an error case where an asset
-	// split type is not `asset.Normal`.
+	// split type does not match the root asset.
 	ErrInvalidSplitAssetType
 
 	// ErrInvalidSplitCommitmentWitness represents an error case where an

--- a/vm/vm.go
+++ b/vm/vm.go
@@ -105,12 +105,10 @@ func matchesAssetParams(newAsset, prevAsset *asset.Asset,
 // input. This is done by verifying the asset split is committed to within the
 // new asset's split commitment root through its split commitment proof.
 func (vm *Engine) validateSplit() error {
-	// Only `Normal` assets can be split, and the change asset should have
-	// a split commitment root.
+	// The asset type must match for all parts of a split, and the change
+	// asset should have a split commitment root.
 	switch {
-	case vm.newAsset.Type != asset.Normal ||
-		vm.splitAsset.Type != asset.Normal:
-
+	case vm.newAsset.Type != vm.splitAsset.Type:
 		return newErrKind(ErrInvalidSplitAssetType)
 
 	case vm.newAsset.SplitCommitmentRoot == nil:


### PR DESCRIPTION
Depends on #159, addresses #99 and #121.

Adds support for non-interactive sends of collectibles by allowing splits bearing collectibles, iff they have an unspendable root and exactly one non-root locator.

Fixes https://github.com/lightninglabs/taro/issues/99 
Fixes https://github.com/lightninglabs/taro/issues/121