### PR TITLE
tarodb: fix bug in asset coin selection related to key families 

### DIFF
--- a/commitment/asset.go
+++ b/commitment/asset.go
@@ -118,7 +118,8 @@ func parseCommon(assets ...*asset.Asset) (*AssetCommitment, error) {
 
 		key := asset.AssetCommitmentKey()
 		if _, ok := assetsMap[key]; ok {
-			return nil, ErrAssetDuplicateScriptKey
+			return nil, fmt.Errorf("%w: %x",
+				ErrAssetDuplicateScriptKey, key[:])
 		}
 		if asset.Version > maxVersion {
 			maxVersion = asset.Version

--- a/commitment/commitment_test.go
+++ b/commitment/commitment_test.go
@@ -204,7 +204,7 @@ func TestNewAssetCommitment(t *testing.T) {
 		success := t.Run(testCase.name, func(t *testing.T) {
 			assets := testCase.f()
 			commitment, err := NewAssetCommitment(assets...)
-			require.Equal(t, testCase.err, err)
+			require.ErrorIs(t, err, testCase.err)
 			if testCase.err == nil {
 				// Ensure that the Taro commitment was properly set.
 				require.NotZero(t, commitment.TaroCommitmentKey())

--- a/tarodb/asset_minting.go
+++ b/tarodb/asset_minting.go
@@ -84,7 +84,7 @@ type (
 
 	// AssetFamSig is used to insert the family key signature for a given
 	// asset on disk.
-	AssetFamSig = sqlite.InsertAssetFamilySigParams
+	AssetFamSig = sqlite.UpsertAssetFamilySigParams
 
 	// AssetSprout is used to fetch the set of assets from disk.
 	AssetSprout = sqlite.FetchAssetsForBatchRow

--- a/tarodb/assets_common.go
+++ b/tarodb/assets_common.go
@@ -34,8 +34,8 @@ type UpsertAssetStore interface {
 	// UpsertScriptKey inserts a new script key on disk into the DB.
 	UpsertScriptKey(context.Context, NewScriptKey) (int32, error)
 
-	// InsertAssetFamilySig inserts a new asset family sig into the DB.
-	InsertAssetFamilySig(ctx context.Context, arg AssetFamSig) (int32, error)
+	// UpsertAssetFamilySig inserts a new asset family sig into the DB.
+	UpsertAssetFamilySig(ctx context.Context, arg AssetFamSig) (int32, error)
 
 	// UpsertAssetFamilyKey inserts a new or updates an existing family key
 	// on disk, and returns the primary key.
@@ -218,7 +218,7 @@ func upsertFamilyKey(ctx context.Context, familyKey *asset.FamilyKey,
 	// together otherwise disparate asset IDs).
 	//
 	// TODO(roasbeef): sig here doesn't actually matter?
-	famSigID, err := q.InsertAssetFamilySig(ctx, AssetFamSig{
+	famSigID, err := q.UpsertAssetFamilySig(ctx, AssetFamSig{
 		GenesisSig: familyKey.Sig.Serialize(),
 		GenAssetID: genAssetID,
 		KeyFamID:   famID,

--- a/tarodb/sqlite/assets.sql.go
+++ b/tarodb/sqlite/assets.sql.go
@@ -1392,8 +1392,7 @@ JOIN chain_txns txns
     ON utxos.txn_id = txns.txn_id
 WHERE (
     assets.amount >= COALESCE($3, assets.amount) AND
-    ((length(hex($4)) == 0 OR 
-        key_fam_info_view.tweaked_fam_key = $4))
+    (key_fam_info_view.tweaked_fam_key = $4 OR $4 IS NULL)
 )
 `
 
@@ -1401,7 +1400,7 @@ type QueryAssetsParams struct {
 	AssetIDFilter interface{}
 	AnchorPoint   interface{}
 	MinAmt        sql.NullInt64
-	KeyFamFilter  interface{}
+	KeyFamFilter  []byte
 }
 
 type QueryAssetsRow struct {

--- a/tarodb/sqlite/migrations/000002_assets.up.sql
+++ b/tarodb/sqlite/migrations/000002_assets.up.sql
@@ -94,7 +94,7 @@ CREATE TABLE IF NOT EXISTS asset_family_sigs (
     genesis_sig BLOB NOT NULL, 
 
     -- TODO(roasbeef): not needed since already in assets row?
-    gen_asset_id INTEGER NOT NULL REFERENCES genesis_assets(gen_asset_id),
+    gen_asset_id INTEGER NOT NULL REFERENCES genesis_assets(gen_asset_id) UNIQUE,
 
     key_fam_id INTEGER NOT NULL REFERENCES asset_families(family_id)
 );

--- a/tarodb/sqlite/querier.go
+++ b/tarodb/sqlite/querier.go
@@ -56,7 +56,6 @@ type Querier interface {
 	GetRootKey(ctx context.Context, id []byte) (Macaroon, error)
 	InsertAddr(ctx context.Context, arg InsertAddrParams) (int32, error)
 	InsertAssetDelta(ctx context.Context, arg InsertAssetDeltaParams) error
-	InsertAssetFamilySig(ctx context.Context, arg InsertAssetFamilySigParams) (int32, error)
 	InsertAssetSeedling(ctx context.Context, arg InsertAssetSeedlingParams) error
 	InsertAssetSeedlingIntoBatch(ctx context.Context, arg InsertAssetSeedlingIntoBatchParams) error
 	InsertAssetTransfer(ctx context.Context, arg InsertAssetTransferParams) (int32, error)
@@ -91,6 +90,7 @@ type Querier interface {
 	UpdateMintingBatchState(ctx context.Context, arg UpdateMintingBatchStateParams) error
 	UpsertAddrEvent(ctx context.Context, arg UpsertAddrEventParams) (int32, error)
 	UpsertAssetFamilyKey(ctx context.Context, arg UpsertAssetFamilyKeyParams) (int32, error)
+	UpsertAssetFamilySig(ctx context.Context, arg UpsertAssetFamilySigParams) (int32, error)
 	UpsertAssetProof(ctx context.Context, arg UpsertAssetProofParams) error
 	UpsertChainTx(ctx context.Context, arg UpsertChainTxParams) (int32, error)
 	UpsertGenesisAsset(ctx context.Context, arg UpsertGenesisAssetParams) (int32, error)

--- a/tarodb/sqlite/queries/assets.sql
+++ b/tarodb/sqlite/queries/assets.sql
@@ -120,12 +120,14 @@ INSERT INTO asset_families (
     DO UPDATE SET genesis_point_id = EXCLUDED.genesis_point_id
 RETURNING family_id;
 
--- name: InsertAssetFamilySig :one
+-- name: UpsertAssetFamilySig :one
 INSERT INTO asset_family_sigs (
     genesis_sig, gen_asset_id, key_fam_id
 ) VALUES (
     ?, ?, ?
-) RETURNING sig_id;
+) ON CONFLICT (gen_asset_id)
+    DO UPDATE SET gen_asset_id = EXCLUDED.gen_asset_id
+RETURNING sig_id;
 
 -- name: UpsertGenesisAsset :one
 INSERT INTO genesis_assets (

--- a/tarodb/sqlite/queries/assets.sql
+++ b/tarodb/sqlite/queries/assets.sql
@@ -264,9 +264,7 @@ JOIN genesis_info_view
 -- doesn't have a family key. See the comment in fetchAssetSprouts for a work
 -- around that needs to be used with this query until a sqlc bug is fixed.
 LEFT JOIN key_fam_info_view
-    ON assets.genesis_id = key_fam_info_view.gen_asset_id AND
-        (length(hex(sqlc.narg('key_fam_filter'))) == 0 OR 
-            key_fam_info_view.tweaked_fam_key = sqlc.narg('key_fam_filter'))
+    ON assets.genesis_id = key_fam_info_view.gen_asset_id
 JOIN script_keys
     on assets.script_key_id = script_keys.script_key_id
 JOIN internal_keys
@@ -284,7 +282,9 @@ JOIN chain_txns txns
 -- make the entire statement evaluate to true, if none of these extra args are
 -- specified.
 WHERE (
-    assets.amount >= COALESCE(sqlc.narg('min_amt'), assets.amount)
+    assets.amount >= COALESCE(sqlc.narg('min_amt'), assets.amount) AND
+    ((length(hex(sqlc.narg('key_fam_filter'))) == 0 OR 
+        key_fam_info_view.tweaked_fam_key = sqlc.narg('key_fam_filter')))
 );
 
 -- name: AllAssets :many

--- a/tarodb/sqlite/queries/assets.sql
+++ b/tarodb/sqlite/queries/assets.sql
@@ -285,8 +285,7 @@ JOIN chain_txns txns
 -- specified.
 WHERE (
     assets.amount >= COALESCE(sqlc.narg('min_amt'), assets.amount) AND
-    ((length(hex(sqlc.narg('key_fam_filter'))) == 0 OR 
-        key_fam_info_view.tweaked_fam_key = sqlc.narg('key_fam_filter')))
+    (key_fam_info_view.tweaked_fam_key = sqlc.narg('key_fam_filter') OR sqlc.narg('key_fam_filter') IS NULL)
 );
 
 -- name: AllAssets :many

--- a/tarofreighter/chain_porter.go
+++ b/tarofreighter/chain_porter.go
@@ -588,7 +588,8 @@ func (p *ChainPorter) stateStep(currentPkg sendPackage) (*sendPackage, error) {
 			ctx, constraints,
 		)
 		if err != nil {
-			return nil, err
+			return nil, fmt.Errorf("unable to complete coin "+
+				"selection: %w", err)
 		}
 
 		log.Infof("Selected %v possible asset inputs for send to %x",
@@ -693,7 +694,8 @@ func (p *ChainPorter) stateStep(currentPkg sendPackage) (*sendPackage, error) {
 			*currentPkg.SenderScriptKey.PubKey, *currentPkg.SendDelta,
 		)
 		if err != nil {
-			return nil, err
+			return nil, fmt.Errorf("unable to create split "+
+				"commit: %w", err)
 		}
 
 		currentPkg.SendDelta = preparedSpend
@@ -732,7 +734,8 @@ func (p *ChainPorter) stateStep(currentPkg sendPackage) (*sendPackage, error) {
 			p.cfg.Signer, p.cfg.TxValidator,
 		)
 		if err != nil {
-			return nil, err
+			return nil, fmt.Errorf("unable to generate taro "+
+				"witness data: %w", err)
 		}
 
 		currentPkg.SendDelta = completedSpend
@@ -752,7 +755,8 @@ func (p *ChainPorter) stateStep(currentPkg sendPackage) (*sendPackage, error) {
 			*currentPkg.SenderScriptKey.PubKey,
 		)
 		if err != nil {
-			return nil, err
+			return nil, fmt.Errorf("unable to create new output "+
+				"commitments: %w", err)
 		}
 
 		log.Infof("Constructing new Taro commitments for send to: %x",

--- a/tarofreighter/parcel.go
+++ b/tarofreighter/parcel.go
@@ -81,6 +81,50 @@ const (
 	SendStateWaitingConf
 )
 
+// String returns a human readable version of SendState.
+func (s SendState) String() string {
+	switch s {
+	case SendStateInitializing:
+		return "SendStateInitializing"
+
+	case SendStateCommitmentSelect:
+		return "SendStateCommitmentSelect"
+
+	case SendStateValidatedInput:
+		return "SendStateValidatedInput"
+
+	case SendStatePreparedSplit:
+		return "SendStatePreparedSplit"
+
+	case SendStatePreparedComplete:
+		return "SendStatePreparedComplete"
+
+	case SendStateSigned:
+		return "SendStateSigned"
+
+	case SendStateCommitmentsUpdated:
+		return "SendStateCommitmentsUpdated"
+
+	case SendStatePsbtFund:
+		return "SendStatePsbtFund"
+
+	case SendStatePsbtSign:
+		return "SendStatePsbtSign"
+
+	case SendStateLogCommit:
+		return "SendStateLogCommit"
+
+	case SendStateBroadcast:
+		return "SendStateBroadcast"
+
+	case SendStateWaitingConf:
+		return "SendStateWaitingConf"
+
+	default:
+		return fmt.Sprintf("<unknown_state(%d)>", s)
+	}
+}
+
 // AssetParcel is the main request to issue an asset transfer. This packages a
 // destination address, and also response context.
 type AssetParcel struct {


### PR DESCRIPTION
In this commit we fix a bug that would cause all assets (that matched the other predicates) to be returned when we issue a query that attempts to filter based on just key family. This was due to the `LEFT JOIN` usage in the main query. Before this fix, this meant that all other assets that matched up to that point would be returned in addition to the ones that matched the key family fitler. 

To fix this, we move the filtering into the `WHERE` clause which ensures we only get the precise results we need. Along the way we've added some more debugging context to errors, and also added new test cases to exercise the fixes added. 