### PR TITLE
multi: run make fmt

### DIFF
--- a/cmd/tarocli/addrs.go
+++ b/cmd/tarocli/addrs.go
@@ -142,7 +142,7 @@ func queryAddr(ctx *cli.Context) error {
 	}
 
 	// Wrap with int64() so math.MaxInt64 will cross-compile on 32-bit arch.
-	end := int64(math.MaxInt64) 
+	end := int64(math.MaxInt64)
 	if ctx.IsSet(createdBeforeName) {
 		endOffset, err := time.ParseDuration(ctx.String(createdBeforeName))
 		if err != nil {

--- a/rpcperms/interceptor.go
+++ b/rpcperms/interceptor.go
@@ -63,28 +63,28 @@ var (
 // client with a macaroon that contains a custom caveat that is supported by one
 // of the registered middlewares.
 //
-//        |
-//        | gRPC request from client
-//        |
-//    +---v--------------------------------+
-//    |   InterceptorChain                 |
-//    +-+----------------------------------+
-//      | Log Interceptor                  |
-//      +----------------------------------+
-//      | RPC State Interceptor            |
-//      +----------------------------------+
-//      | Macaroon Interceptor             |
-//      +----------------------------------+
-//      | Prometheus Interceptor           |
-//      +-+--------------------------------+
-//        | validated gRPC request from client
-//    +---v--------------------------------+
-//    |   main gRPC server                 |
-//    +---+--------------------------------+
-//        |
-//        | original gRPC request to client
-//        |
-//        v
+//	    |
+//	    | gRPC request from client
+//	    |
+//	+---v--------------------------------+
+//	|   InterceptorChain                 |
+//	+-+----------------------------------+
+//	  | Log Interceptor                  |
+//	  +----------------------------------+
+//	  | RPC State Interceptor            |
+//	  +----------------------------------+
+//	  | Macaroon Interceptor             |
+//	  +----------------------------------+
+//	  | Prometheus Interceptor           |
+//	  +-+--------------------------------+
+//	    | validated gRPC request from client
+//	+---v--------------------------------+
+//	|   main gRPC server                 |
+//	+---+--------------------------------+
+//	    |
+//	    | original gRPC request to client
+//	    |
+//	    v
 type InterceptorChain struct {
 	// lastRequestID is the ID of the last gRPC request or stream that was
 	// intercepted by the middleware interceptor.

--- a/tarodb/assets_store_test.go
+++ b/tarodb/assets_store_test.go
@@ -742,7 +742,7 @@ func TestAssetExportLog(t *testing.T) {
 
 	newWitness := asset.Witness{
 		PrevID:          &asset.PrevID{},
-		TxWitness:       [][]byte{[]byte{0x01}, []byte{0x02}},
+		TxWitness:       [][]byte{{0x01}, {0x02}},
 		SplitCommitment: nil,
 	}
 
@@ -779,7 +779,7 @@ func TestAssetExportLog(t *testing.T) {
 				SplitCommitmentRoot: mssmt.NewComputedNode(
 					newRootHash, newRootValue,
 				),
-				WitnessData: []asset.Witness{newWitness},
+				WitnessData:        []asset.Witness{newWitness},
 				SenderAssetProof:   senderBlob,
 				ReceiverAssetProof: receiverBlob,
 			},


### PR DESCRIPTION
Fixes a few formatting errors, that also could have the linter failing.