### PR TITLE
multi: encode/decode keys with their parity byte

### DIFF
--- a/address/records.go
+++ b/address/records.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 
 	"github.com/btcsuite/btcd/btcec/v2"
-	"github.com/btcsuite/btcd/btcec/v2/schnorr"
 	"github.com/lightninglabs/taro/asset"
 	"github.com/lightningnetwork/lnd/tlv"
 )
@@ -58,22 +57,22 @@ func newAddressGenesisRecord(genesis *asset.Genesis) tlv.Record {
 
 func newAddressFamilyKeyRecord(familyKey **btcec.PublicKey) tlv.Record {
 	return tlv.MakeStaticRecord(
-		addrFamKeyType, familyKey, schnorr.PubKeyBytesLen,
-		asset.SchnorrPubKeyEncoder, asset.SchnorrPubKeyDecoder,
+		addrFamKeyType, familyKey, btcec.PubKeyBytesLenCompressed,
+		asset.CompressedPubKeyEncoder, asset.CompressedPubKeyDecoder,
 	)
 }
 
 func newAddressScriptKeyRecord(scriptKey *btcec.PublicKey) tlv.Record {
 	return tlv.MakeStaticRecord(
-		addrScriptKeyType, scriptKey, schnorr.PubKeyBytesLen,
-		schnorrPubKeyEncoder, schnorrPubKeyDecoder,
+		addrScriptKeyType, scriptKey, btcec.PubKeyBytesLenCompressed,
+		compressedPubKeyEncoder, compressedPubKeyDecoder,
 	)
 }
 
 func newAddressInternalKeyRecord(internalKey *btcec.PublicKey) tlv.Record {
 	return tlv.MakeStaticRecord(
-		addrInternalKeyType, internalKey, schnorr.PubKeyBytesLen,
-		schnorrPubKeyEncoder, schnorrPubKeyDecoder,
+		addrInternalKeyType, internalKey, btcec.PubKeyBytesLenCompressed,
+		compressedPubKeyEncoder, compressedPubKeyDecoder,
 	)
 }
 

--- a/asset/asset_test.go
+++ b/asset/asset_test.go
@@ -19,9 +19,9 @@ var (
 	hashBytes1     = [32]byte{1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1}
 	hashBytes2     = [32]byte{2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2}
 	pubKeyBytes, _ = hex.DecodeString(
-		"a0afeb165f0ec36880b68e0baabd9ad9c62fd1a69aa998bc30e9a346202e078f",
+		"03a0afeb165f0ec36880b68e0baabd9ad9c62fd1a69aa998bc30e9a346202e078f",
 	)
-	pubKey, _   = schnorr.ParsePubKey(pubKeyBytes)
+	pubKey, _   = btcec.ParsePubKey(pubKeyBytes)
 	sigBytes, _ = hex.DecodeString(
 		"e907831f80848d1069a5371b402410364bdf1c5f8307b0084c55f1ce2dca821525f66a4a85ea8b71e482a74f382d2ce5ebeee8fdb2172f477df4900d310536c0",
 	)

--- a/asset/records.go
+++ b/asset/records.go
@@ -136,15 +136,15 @@ func NewLeafScriptVersionRecord(version *ScriptVersion) tlv.Record {
 }
 
 func NewLeafScriptKeyRecord(scriptKey **btcec.PublicKey) tlv.Record {
-	const recordSize = schnorr.PubKeyBytesLen
+	const recordSize = btcec.PubKeyBytesLenCompressed
 	return tlv.MakeStaticRecord(
 		LeafScriptKey, scriptKey, recordSize,
-		SchnorrPubKeyEncoder, SchnorrPubKeyDecoder,
+		CompressedPubKeyEncoder, CompressedPubKeyDecoder,
 	)
 }
 
 func NewLeafFamilyKeyRecord(familyKey **FamilyKey) tlv.Record {
-	const recordSize = schnorr.PubKeyBytesLen + schnorr.SignatureSize
+	const recordSize = btcec.PubKeyBytesLenCompressed + schnorr.SignatureSize
 	return tlv.MakeStaticRecord(
 		LeafFamilyKey, familyKey, recordSize, FamilyKeyEncoder,
 		FamilyKeyDecoder,
@@ -153,13 +153,13 @@ func NewLeafFamilyKeyRecord(familyKey **FamilyKey) tlv.Record {
 
 func NewLeafFamilyKeyOnlyRecord(familyKey **btcec.PublicKey) tlv.Record {
 	return tlv.MakeStaticRecord(
-		LeafFamilyKey, familyKey, schnorr.PubKeyBytesLen,
-		SchnorrPubKeyEncoder, SchnorrPubKeyDecoder,
+		LeafFamilyKey, familyKey, btcec.PubKeyBytesLenCompressed,
+		CompressedPubKeyEncoder, CompressedPubKeyDecoder,
 	)
 }
 
 func NewWitnessPrevIDRecord(prevID **PrevID) tlv.Record {
-	const recordSize = 36 + sha256.Size + schnorr.PubKeyBytesLen
+	const recordSize = 36 + sha256.Size + btcec.PubKeyBytesLenCompressed
 	return tlv.MakeStaticRecord(
 		WitnessPrevID, prevID, recordSize, PrevIDEncoder, PrevIDDecoder,
 	)

--- a/proof/records.go
+++ b/proof/records.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 
 	"github.com/btcsuite/btcd/btcec/v2"
-	"github.com/btcsuite/btcd/btcec/v2/schnorr"
 	"github.com/btcsuite/btcd/wire"
 	"github.com/lightninglabs/taro/asset"
 	"github.com/lightninglabs/taro/commitment"
@@ -161,8 +160,9 @@ func TaprootProofOutputIndexRecord(idx *uint32) tlv.Record {
 
 func TaprootProofInternalKeyRecord(internalKey **btcec.PublicKey) tlv.Record {
 	return tlv.MakeStaticRecord(
-		TaprootProofInternalKeyType, internalKey, schnorr.PubKeyBytesLen,
-		asset.SchnorrPubKeyEncoder, asset.SchnorrPubKeyDecoder,
+		TaprootProofInternalKeyType, internalKey,
+		btcec.PubKeyBytesLenCompressed,
+		asset.CompressedPubKeyEncoder, asset.CompressedPubKeyDecoder,
 	)
 }
 


### PR DESCRIPTION
Spinoff of #176.

Currently public keys are sometimes (such as in addresses) unconditionally encoded with an even parity. If that key actually has odd parity, and is already stored, then key upserts behave incorrectly, causing other issues.

To resolve this, we migrate all key encoding & decoding away from the x-only format to the compressed format. This adds a few bytes to the size of some types when encoded, but other techniques can be used to compactly repesented key parity for those types.

Requires BIP updates.