### PR TITLE
chanutils: simplify type params for ErrGroup

### DIFF
--- a/chanutils/concurrency.go
+++ b/chanutils/concurrency.go
@@ -7,17 +7,18 @@ import (
 	"golang.org/x/sync/errgroup"
 )
 
-// ErrGroup is iterating through values and calls func
-// then waiting for all goroutines to report back.
-// Active goroutines limited with number of CPU.
-// Context will be passed in executable func
-// and canceled the first time a function passed returns a non-nil error.
-// Returns the first non-nil error (if any).
-func ErrGroup[V any, S []V](
-	ctx context.Context,
-	f func(context.Context, V) error,
-	s S) error {
+// ErrFunc is a type def for a function that takes a context (to allow early
+// cancellation) and a series of value returning an error. This is typically
+// used a closure to perform concurrent work over a homogeneous slice of
+// values.
+type ErrFunc[V any] func(context.Context, V) error
 
+// ErrGroup is iterating through values and calls func then waiting for all
+// goroutines to report back.  Active goroutines limited with number of CPU.
+// Context will be passed in executable func and canceled the first time a
+// function passed returns a non-nil error.  Returns the first non-nil error
+// (if any).
+func ErrGroup[V any](ctx context.Context, s []V, f ErrFunc[V]) error {
 	errGroup, ctx := errgroup.WithContext(ctx)
 	errGroup.SetLimit(runtime.NumCPU())
 

--- a/chanutils/concurrency_test.go
+++ b/chanutils/concurrency_test.go
@@ -50,7 +50,9 @@ func TestErrGroup(t *testing.T) {
 		test := test
 		t.Run(test.name, func(t *testing.T) {
 			t.Parallel()
-			e := ErrGroup(context.TODO(), returnErrFunc, test.values)
+			e := ErrGroup(
+				context.TODO(), test.values, returnErrFunc,
+			)
 			require.Contains(t, test.expectedErrors, e)
 		})
 	}

--- a/proof/archive.go
+++ b/proof/archive.go
@@ -302,7 +302,7 @@ func (m *MultiArchiver) ImportProofs(ctx context.Context,
 		return nil
 	}
 
-	if err := chanutils.ErrGroup(ctx, f, proofs); err != nil {
+	if err := chanutils.ErrGroup(ctx, proofs, f); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
In this commit, we simplify the type params a bit by using a new function type def, and eliminating an extra type params. We also swap the order of the last two args (func closure now last), as the next version allows for syntax like:
```
type Ctx context.Context
err := chanutils.ErrGroup(ctx, links, func(ctx Ctx, link string) error {
    return WebSrape(link)
})
```