### PR TITLE
tarocfg: check cfgLogger for nilness

### DIFF
--- a/tarocfg/config.go
+++ b/tarocfg/config.go
@@ -623,7 +623,7 @@ func ValidateConfig(cfg Config, interceptor signal.Interceptor) (*Config,
 	err = build.ParseAndSetDebugLevels(cfg.DebugLevel, cfg.LogWriter)
 	if err != nil {
 		str := "error parsing debug level: %v"
-		return nil, nil, &usageError{mkErr(str, err)}
+		return nil, taroCfgLog, &usageError{mkErr(str, err)}
 	}
 
 	// At least one RPCListener is required. So listen on localhost per
@@ -650,7 +650,7 @@ func ValidateConfig(cfg Config, interceptor signal.Interceptor) (*Config,
 		cfg.net.ResolveTCPAddr,
 	)
 	if err != nil {
-		return nil, nil, mkErr("error normalizing RPC listen addrs: %v", err)
+		return nil, taroCfgLog, mkErr("error normalizing RPC listen addrs: %v", err)
 	}
 
 	// Add default port to all REST listener addresses if needed and remove
@@ -660,7 +660,7 @@ func ValidateConfig(cfg Config, interceptor signal.Interceptor) (*Config,
 		cfg.net.ResolveTCPAddr,
 	)
 	if err != nil {
-		return nil, nil, mkErr("error normalizing REST listen addrs: %v", err)
+		return nil, taroCfgLog, mkErr("error normalizing REST listen addrs: %v", err)
 	}
 
 	// For each of the RPC listeners (REST+gRPC), we'll ensure that users
@@ -671,7 +671,7 @@ func ValidateConfig(cfg Config, interceptor signal.Interceptor) (*Config,
 		cfg.rpcListeners, !cfg.RpcConf.NoMacaroons, true,
 	)
 	if err != nil {
-		return nil, nil, mkErr("error enforcing safe authentication on "+
+		return nil, taroCfgLog, mkErr("error enforcing safe authentication on "+
 			"RPC ports: %v", err)
 	}
 
@@ -684,7 +684,7 @@ func ValidateConfig(cfg Config, interceptor signal.Interceptor) (*Config,
 			!cfg.RpcConf.DisableRestTLS,
 		)
 		if err != nil {
-			return nil, nil, mkErr("error enforcing safe "+
+			return nil, taroCfgLog, mkErr("error enforcing safe "+
 				"authentication on REST ports: %v", err)
 		}
 	}


### PR DESCRIPTION
Since the logger most likely won't be initialized in the error case,
trying to use it would cause a panic.