### PR TITLE
cmd: reverse txid bytes before printing them

### DIFF
--- a/cmd/tarocli/assets.go
+++ b/cmd/tarocli/assets.go
@@ -123,12 +123,16 @@ func listAssets(ctx *cli.Context) error {
 	client, cleanUp := getClient(ctx)
 	defer cleanUp()
 
-	// TODO(roasbeef): need to reverse txid
-
 	resp, err := client.ListAssets(ctxc, &tarorpc.ListAssetRequest{})
 	if err != nil {
 		return fmt.Errorf("unable to list assets: %w", err)
 	}
+
+	// Reverse TxIDs before printing them.
+	for i := range resp.Assets {
+		reverseTxIDBytes(resp.Assets[i].ChainAnchor.AnchorTxid)
+	}
+
 	printRespJSON(resp)
 	return nil
 }
@@ -279,6 +283,9 @@ func sendAssets(ctx *cli.Context) error {
 	if err != nil {
 		return fmt.Errorf("unable to send assets: %w", err)
 	}
+
+	// Reverse TxID before printing them.
+	reverseTxIDBytes(resp.TransferTxid)
 
 	printRespJSON(resp)
 	return nil

--- a/cmd/tarocli/commands.go
+++ b/cmd/tarocli/commands.go
@@ -57,6 +57,14 @@ func printRespJSON(resp proto.Message) {
 	fmt.Println(jsonStr)
 }
 
+// reverseTxIDBytes reverses the bytes of a transaction hash.
+func reverseTxIDBytes(txid []byte) {
+	size := len(txid)
+	for i := 0; i < size/2; i++ {
+		txid[i], txid[size-1-i] = txid[size-1-i], txid[i]
+	}
+}
+
 var debugLevelCommand = cli.Command{
 	Name:  "debuglevel",
 	Usage: "Set the debug level.",

--- a/tarocfg/server.go
+++ b/tarocfg/server.go
@@ -62,25 +62,25 @@ func CreateServerFromConfig(cfg *Config, cfgLogger btclog.Logger,
 		return nil, fmt.Errorf("unable to open database: %v", err)
 	}
 
-	rksDB := tarodb.NewTransactionExecutor[tarodb.KeyStore](
+	rksDB := tarodb.NewTransactionExecutor(
 		db, func(tx *sql.Tx) tarodb.KeyStore {
 			return db.WithTx(tx)
 		},
 	)
-	mintingStore := tarodb.NewTransactionExecutor[tarodb.PendingAssetStore](
+	mintingStore := tarodb.NewTransactionExecutor(
 		db, func(tx *sql.Tx) tarodb.PendingAssetStore {
 			return db.WithTx(tx)
 		},
 	)
 	assetMintingStore := tarodb.NewAssetMintingStore(mintingStore)
 
-	assetDB := tarodb.NewTransactionExecutor[tarodb.ActiveAssetsStore](
+	assetDB := tarodb.NewTransactionExecutor(
 		db, func(tx *sql.Tx) tarodb.ActiveAssetsStore {
 			return db.WithTx(tx)
 		},
 	)
 
-	addrBookDB := tarodb.NewTransactionExecutor[tarodb.AddrBook](
+	addrBookDB := tarodb.NewTransactionExecutor(
 		db, func(tx *sql.Tx) tarodb.AddrBook {
 			return db.WithTx(tx)
 		},


### PR DESCRIPTION
Ensure that the tx id bytes are properly reversed before printing them so we can use the output directly in chain explorers.

This is something that we need to keep in mind because every time that we add a tx id using `[]bytes` won't match the `string` version used for outpoints (which are [reversed before getting encoded](https://github.com/btcsuite/btcd/blob/718d268a8cf55af9b329bac9e171009352fbc10a/chaincfg/chainhash/hash.go#L71)).

Fixes [223](https://github.com/lightninglabs/taro/issues/223)