### PR TITLE
Minting timer fix

### DIFF
--- a/tarocfg/server.go
+++ b/tarocfg/server.go
@@ -151,7 +151,7 @@ func CreateServerFromConfig(cfg *Config, cfgLogger btclog.Logger,
 				),
 				ProofFiles: proofFileStore,
 			},
-			BatchTicker: ticker.New(cfg.BatchMintingInterval),
+			BatchTicker: ticker.NewForce(cfg.BatchMintingInterval),
 			ErrChan:     mainErrChan,
 		}),
 		AssetCustodian: tarogarden.NewCustodian(

--- a/tarogarden/planter.go
+++ b/tarogarden/planter.go
@@ -47,7 +47,7 @@ type PlanterConfig struct {
 
 	// BatchTicker is used to notify the planter than it should assemble
 	// all asset requests into a new batch.
-	BatchTicker ticker.Ticker
+	BatchTicker *ticker.Force
 
 	// ErrChan is the main error channel the planter will report back
 	// critical errors to the main server.
@@ -206,6 +206,8 @@ func (c *ChainPlanter) Start() error {
 		// new minting requests.
 		c.Wg.Add(1)
 		go c.gardener()
+
+		c.cfg.BatchTicker.Resume()
 	})
 
 	return startErr
@@ -270,33 +272,9 @@ func (c *ChainPlanter) gardener() {
 
 	log.Infof("Gardener for ChainPlanter now active!")
 
-	// TODO(roasbeef): use top level ticker.Force instead?
-	batchTicker := make(chan time.Time, 1)
-
-	c.Wg.Add(1)
-	go func() {
-		defer c.Wg.Done()
-
-		// Forward any ticks from the main ticker into this channel.
-		// This lets us trigger manual ticks, but also make sure we're
-		// grabbing the real set of ticks.
-		select {
-		case tick := <-c.cfg.BatchTicker.Ticks():
-
-			select {
-			case batchTicker <- tick:
-			case <-c.Quit:
-				return
-			}
-
-		case <-c.Quit:
-			return
-		}
-	}()
-
 	for {
 		select {
-		case <-batchTicker:
+		case <-c.cfg.BatchTicker.Ticks():
 			// No pending batch, so we can just continue back to
 			// the top of the loop.
 			if c.pendingBatch == nil {
@@ -371,7 +349,11 @@ func (c *ChainPlanter) gardener() {
 			// current batch.
 			if batchNow {
 				log.Infof("Forcing new batch for %v", req)
-				batchTicker <- time.Time{}
+				// A force tick must be sent in a separate
+				// goroutine to prevent deadlock.
+				go func() {
+					c.cfg.BatchTicker.Force <- time.Time{}
+				}()
 			}
 
 		// A caretaker has finished processing their batch to full Taro

--- a/tarogarden/planter_test.go
+++ b/tarogarden/planter_test.go
@@ -211,7 +211,10 @@ func (t *mintingTestHarness) assertNoPendingBatch() {
 func (t *mintingTestHarness) tickMintingBatch() {
 	t.Helper()
 
-	t.ticker.Force <- time.Time{}
+	ticked, err := t.planter.ForceBatch()
+
+	require.NoError(t, err)
+	require.True(t, ticked)
 }
 
 // assertNumCaretakersActive asserts that the specified number of caretakers


### PR DESCRIPTION
Fixes a bug discovered in #212 where the minting batch ticker was never started when `tarod` was started.

Adds a planter test that relies on the ticker instead of forcing a batch.

Have verified the ticker working with `tarod` outside of itest and unit tests.