### PR TITLE
Add local aperture service to itest

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,6 +26,7 @@ RM := rm -f
 CP := cp
 MAKE := make
 XARGS := xargs -L 1
+UNAME_S := $(shell uname -s)
 
 include make/testing_flags.mk
 include make/release_flags.mk
@@ -135,10 +136,18 @@ unit-race:
 
 itest: build-itest itest-only
 
-itest-only:
+itest-only: aperture-dir
 	@$(call print, "Running integration tests with ${backend} backend.")
 	rm -rf itest/regtest; date
 	$(GOTEST) ./itest -v -tags="$(ITEST_TAGS)" $(TEST_FLAGS) $(ITEST_FLAGS) -btcdexec=./btcd-itest -logdir=regtest
+
+aperture-dir:
+ifeq ($(UNAME_S),Linux)
+	mkdir -p $$HOME/.aperture
+endif
+ifeq ($(UNAME_S),Darwin)
+	mkdir -p "$$HOME/Library/Application Support/Aperture"
+endif
 
 # =============
 # FLAKE HUNTING

--- a/go.mod
+++ b/go.mod
@@ -19,6 +19,7 @@ require (
 	github.com/jackc/pgerrcode v0.0.0-20201024163028-a0d42d470451
 	github.com/jessevdk/go-flags v1.4.0
 	github.com/lib/pq v1.10.3
+	github.com/lightninglabs/aperture v0.1.19-beta
 	github.com/lightninglabs/lightning-node-connect/hashmailrpc v1.0.2
 	github.com/lightninglabs/lndclient v0.16.0-6
 	github.com/lightninglabs/protobuf-hex-display v1.4.3-hex-display

--- a/go.sum
+++ b/go.sum
@@ -284,6 +284,7 @@ github.com/fergusstrange/embedded-postgres v1.10.0/go.mod h1:a008U8/Rws5FtIOTGYD
 github.com/form3tech-oss/jwt-go v3.2.2+incompatible/go.mod h1:pbq4aXjuKjdthFRnoDwaVPLA+WlJuPGy+QneDUgJi2k=
 github.com/form3tech-oss/jwt-go v3.2.3+incompatible h1:7ZaBxOI7TMoYBfyA3cQHErNNyAWIKUMIwqxEtgHOs5c=
 github.com/form3tech-oss/jwt-go v3.2.3+incompatible/go.mod h1:pbq4aXjuKjdthFRnoDwaVPLA+WlJuPGy+QneDUgJi2k=
+github.com/fortytw2/leaktest v1.3.0 h1:u8491cBMTQ8ft8aeV+adlcytMZylmA5nnwwkRZjI8vw=
 github.com/frankban/quicktest v1.0.0/go.mod h1:R98jIehRai+d1/3Hv2//jOVCTJhW1VBavT6B6CuGq2k=
 github.com/frankban/quicktest v1.2.2/go.mod h1:Qh/WofXFeiAFII1aEBu529AtJo6Zg2VHscnEsbBnJ20=
 github.com/frankban/quicktest v1.11.3 h1:8sXhOn0uLys67V8EsXLc6eszDs8VXWxL3iRvebPhedY=
@@ -644,6 +645,8 @@ github.com/lib/pq v1.10.0/go.mod h1:AlVN5x4E4T544tWzH6hKfbfQvm3HdbOxrmggDNAPY9o=
 github.com/lib/pq v1.10.2/go.mod h1:AlVN5x4E4T544tWzH6hKfbfQvm3HdbOxrmggDNAPY9o=
 github.com/lib/pq v1.10.3 h1:v9QZf2Sn6AmjXtQeFpdoq/eaNtYP6IN+7lcrygsIAtg=
 github.com/lib/pq v1.10.3/go.mod h1:AlVN5x4E4T544tWzH6hKfbfQvm3HdbOxrmggDNAPY9o=
+github.com/lightninglabs/aperture v0.1.19-beta h1:zo/7mpcQdBmSsqsvFrJ4Y3UiL7RJZZonF4zzXgJDzVs=
+github.com/lightninglabs/aperture v0.1.19-beta/go.mod h1:oZTfXXmilM2SEzSYiPfwcbi/Z3IKFsaMP6cF6yAnqeI=
 github.com/lightninglabs/gozmq v0.0.0-20191113021534-d20a764486bf h1:HZKvJUHlcXI/f/O0Avg7t8sqkPo78HFzjmeYFl6DPnc=
 github.com/lightninglabs/gozmq v0.0.0-20191113021534-d20a764486bf/go.mod h1:vxmQPeIQxPf6Jf9rM8R+B4rKBqLA2AjttNxkFBL2Plk=
 github.com/lightninglabs/lightning-node-connect/hashmailrpc v1.0.2 h1:Er1miPZD2XZwcfE4xoS5AILqP1mj7kqnhbBSxW9BDxY=
@@ -903,8 +906,8 @@ github.com/vishvananda/netns v0.0.0-20191106174202-0a2b9b5464df/go.mod h1:JP3t17
 github.com/xanzy/go-gitlab v0.15.0/go.mod h1:8zdQa/ri1dfn8eS3Ir1SyfvOKlw7WBJ8DVThkpGiXrs=
 github.com/xdg-go/pbkdf2 v1.0.0/go.mod h1:jrpuAogTd400dnrH08LKmI/xc1MbPOebTwRqcT5RDeI=
 github.com/xdg-go/scram v1.0.2/go.mod h1:1WAq6h33pAW+iRreB34OORO2Nf7qel3VV3fjBj+hCSs=
-github.com/xdg-go/stringprep v1.0.2 h1:6iq84/ryjjeRmMJwxutI51F2GIPlP5BfTvXHeYjyhBc=
 github.com/xdg-go/stringprep v1.0.2/go.mod h1:8F9zXuvzgwmyT5DUm4GUfZGDdT3W+LCvS6+da4O5kxM=
+github.com/xdg-go/stringprep v1.0.4 h1:XLI/Ng3O1Atzq0oBs3TWm+5ZVgkq2aqdlvP9JtoZ6c8=
 github.com/xeipuuv/gojsonpointer v0.0.0-20180127040702-4e3ac2762d5f h1:J9EGpcZtP0E/raorCMxlFGSTBrsSlaDGf3jU/qvAE2c=
 github.com/xeipuuv/gojsonpointer v0.0.0-20180127040702-4e3ac2762d5f/go.mod h1:N2zxlSyiKSe5eX1tZViRH5QA0qijqEDrYZiPEAiq3wU=
 github.com/xeipuuv/gojsonreference v0.0.0-20180127040603-bd5ef7bd5415 h1:EzJWgHovont7NscjpAxXsDA8S8BMYve8Y5+7cuRE7R0=

--- a/itest/addrs_test.go
+++ b/itest/addrs_test.go
@@ -34,7 +34,8 @@ func testAddresses(t *harnessTest) {
 	// We'll make a second node now that'll be the receiver of all the
 	// assets made above.
 	secondTarod := setupTarodHarness(
-		t.t, t, t.lndHarness.BackendCfg, t.lndHarness.Bob, t.universeServer,
+		t.t, t, t.lndHarness.BackendCfg, t.lndHarness.Bob,
+		t.universeServer, false,
 	)
 	defer func() {
 		require.NoError(t.t, secondTarod.stop(true))

--- a/itest/aperture.go
+++ b/itest/aperture.go
@@ -1,0 +1,103 @@
+package itest
+
+import (
+	"crypto/tls"
+	"fmt"
+	"math"
+	"net/http"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/lightninglabs/aperture"
+	"github.com/lightningnetwork/lnd/lntest/wait"
+	"github.com/stretchr/testify/require"
+)
+
+// ApertureHarness is an integration testing harness for the aperture service.
+type ApertureHarness struct {
+	// ListenAddr is the address that the aperture service is listening on.
+	ListenAddr string
+
+	// TlsCertPath is the path to the TLS certificate that the aperture
+	// service is using.
+	TlsCertPath string
+
+	// service is the instance of the aperture service that is running.
+	Service *aperture.Aperture
+}
+
+// setupApertureHarness creates a new instance of the aperture service and
+// starts it. It returns a harness which includes useful values for testing.
+func setupApertureHarness(t *testing.T) ApertureHarness {
+	// Create a temporary directory for the aperture service to use.
+	baseDir := filepath.Join(t.TempDir(), "aperture")
+	err := os.MkdirAll(baseDir, os.ModePerm)
+	require.NoError(t, err)
+
+	listenAddr := fmt.Sprintf("127.0.0.1:%d", nextAvailablePort())
+
+	cfg := &aperture.Config{
+		Insecure:   false,
+		DebugLevel: "debug",
+		ListenAddr: listenAddr,
+		Authenticator: &aperture.AuthConfig{
+			Disable: true,
+		},
+		Etcd: &aperture.EtcdConfig{},
+		HashMail: &aperture.HashMailConfig{
+			Enabled:               true,
+			MessageRate:           time.Millisecond,
+			MessageBurstAllowance: math.MaxUint32,
+		},
+		Prometheus: &aperture.PrometheusConfig{},
+		Tor:        &aperture.TorConfig{},
+		BaseDir:    baseDir,
+	}
+	service := aperture.NewAperture(cfg)
+
+	// Start aperture service asynchronously.
+	t.Logf("Starting aperture service on %s", listenAddr)
+	errChan := make(chan error)
+	require.NoError(t, service.Start(errChan))
+
+	// Check for error produced while starting.
+	select {
+	case err := <-errChan:
+		t.Fatalf("error starting aperture: %v", err)
+	default:
+	}
+
+	// Ping service to ensure successful start.
+	apertureStartTimeout := 3 * time.Second
+	err = wait.NoError(func() error {
+		// Create a http client that will not check for a valid
+		// certificate.
+		tr := &http.Transport{
+			TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
+		}
+		client := &http.Client{Transport: tr}
+
+		// Check for successful service start by querying the dummy
+		// endpoint.
+		apertureAddr := fmt.Sprintf("https://%s/dummy", listenAddr)
+		resp, err := client.Get(apertureAddr)
+		if err != nil {
+			return err
+		}
+		defer resp.Body.Close()
+		if resp.StatusCode != http.StatusNotFound {
+			return fmt.Errorf("invalid status: %d", resp.StatusCode)
+		}
+
+		return nil
+	}, apertureStartTimeout)
+	require.NoError(t, err)
+
+	return ApertureHarness{
+		ListenAddr:  listenAddr,
+		TlsCertPath: filepath.Join(baseDir, "tls.cert"),
+		Service:     service,
+	}
+}

--- a/itest/assets_test.go
+++ b/itest/assets_test.go
@@ -72,6 +72,7 @@ func mintAssets(t *harnessTest) {
 	charlie := t.lndHarness.NewNode(t.t, "charlie", lndDefaultArgs)
 	secondTarod := setupTarodHarness(
 		t.t, t, t.lndHarness.BackendCfg, charlie, t.universeServer,
+		false,
 	)
 	defer shutdownAndAssert(t, charlie, secondTarod)
 

--- a/itest/collectible_split_test.go
+++ b/itest/collectible_split_test.go
@@ -27,7 +27,8 @@ func testCollectibleSend(t *harnessTest) {
 	// Now that we have the asset created, we'll make a new node that'll
 	// serve as the node which'll receive the assets.
 	secondTarod := setupTarodHarness(
-		t.t, t, t.lndHarness.BackendCfg, t.lndHarness.Bob, t.universeServer,
+		t.t, t, t.lndHarness.BackendCfg, t.lndHarness.Bob,
+		t.universeServer, false,
 	)
 	defer func() {
 		require.NoError(t.t, secondTarod.stop(true))

--- a/itest/full_value_split_test.go
+++ b/itest/full_value_split_test.go
@@ -24,7 +24,8 @@ func testFullValueSend(t *harnessTest) {
 	// Now that we have the asset created, we'll make a new node that'll
 	// serve as the node which'll receive the assets.
 	secondTarod := setupTarodHarness(
-		t.t, t, t.lndHarness.BackendCfg, t.lndHarness.Bob, t.universeServer,
+		t.t, t, t.lndHarness.BackendCfg, t.lndHarness.Bob,
+		t.universeServer, false,
 	)
 	defer func() {
 		require.NoError(t.t, secondTarod.stop(true))

--- a/itest/integration_test.go
+++ b/itest/integration_test.go
@@ -98,6 +98,10 @@ func TestTaroDaemon(t *testing.T) {
 	err = lndHarness.SetUp(ht.t, "taro-itest", lndDefaultArgs)
 	require.NoError(ht.t, err)
 
+	// Start aperture service and attach to test harness.
+	apertureHarness := setupApertureHarness(ht.t)
+	ht.apertureHarness = &apertureHarness
+
 	// Before we continue on below, we'll wait here until the specified
 	// number of blocks has been mined, to ensure we have complete control
 	// over the extension of the chain. 10 extra block are mined as the

--- a/itest/integration_test.go
+++ b/itest/integration_test.go
@@ -129,7 +129,7 @@ func TestTaroDaemon(t *testing.T) {
 			// created and later discarded for each test run to
 			// assure no state is taken over between runs.
 			tarodHarness, universeServer := setupHarnesses(
-				t1, ht, lndHarness,
+				t1, ht, lndHarness, testCase.enableHashMail,
 			)
 			lndHarness.EnsureConnected(
 				t1, lndHarness.Alice, lndHarness.Bob,

--- a/itest/round_trip_send_test.go
+++ b/itest/round_trip_send_test.go
@@ -25,7 +25,8 @@ func testRoundTripSend(t *harnessTest) {
 	// Now that we have the asset created, we'll make a new node that'll
 	// serve as the node which'll receive the assets.
 	secondTarod := setupTarodHarness(
-		t.t, t, t.lndHarness.BackendCfg, t.lndHarness.Bob, t.universeServer,
+		t.t, t, t.lndHarness.BackendCfg, t.lndHarness.Bob,
+		t.universeServer, false,
 	)
 	defer func() {
 		require.NoError(t.t, secondTarod.stop(true))

--- a/itest/send_test.go
+++ b/itest/send_test.go
@@ -52,7 +52,7 @@ func testBasicSend(t *harnessTest) {
 	// serve as the node which'll receive the assets.
 	secondTarod := setupTarodHarness(
 		t.t, t, t.lndHarness.BackendCfg, t.lndHarness.Bob,
-		t.universeServer,
+		t.universeServer, false,
 	)
 	defer func() {
 		require.NoError(t.t, secondTarod.stop(true))

--- a/itest/tarod_harness.go
+++ b/itest/tarod_harness.go
@@ -48,12 +48,9 @@ type tarodHarness struct {
 // tarodConfig holds all configuration items that are required to start a tarod
 // server.
 type tarodConfig struct {
-	UniverseServer string
-	BackendCfg     lntest.BackendConfig
-	ServerTLSPath  string
-	LndNode        *lntest.HarnessNode
-	NetParams      *chaincfg.Params
-	BaseDir        string
+	LndNode   *lntest.HarnessNode
+	NetParams *chaincfg.Params
+	BaseDir   string
 }
 
 // newTarodHarness creates a new tarod server harness with the given

--- a/itest/tarod_harness.go
+++ b/itest/tarod_harness.go
@@ -116,14 +116,13 @@ func newTarodHarness(ht *harnessTest, cfg tarodConfig,
 		return nil, err
 	}
 
-	// Conditionally avoid setting up the hashmail system. Many
-	// tests don't require the hashmail system.
-	//
-	// We can skip setting up the hashmail system by modifying the config.
-	//
-	// TODO(roasbeef): make local aperture instance in future
-	if !enableHashMail {
-		finalCfg.HashMailAddr = ""
+	// Conditionally use the local hashmail service.
+	finalCfg.HashMailCourier = nil
+	if enableHashMail {
+		finalCfg.HashMailCourier = &tarocfg.HashMailCourierCfg{
+			Addr:        ht.apertureHarness.ListenAddr,
+			TlsCertPath: ht.apertureHarness.TlsCertPath,
+		}
 	}
 
 	return &tarodHarness{

--- a/itest/tarod_harness.go
+++ b/itest/tarod_harness.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"flag"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"sync"
@@ -58,7 +57,7 @@ type tarodConfig struct {
 func newTarodHarness(ht *harnessTest, cfg tarodConfig) (*tarodHarness, error) {
 	if cfg.BaseDir == "" {
 		var err error
-		cfg.BaseDir, err = ioutil.TempDir("", "itest-tarod")
+		cfg.BaseDir, err = os.MkdirTemp("", "itest-tarod")
 		if err != nil {
 			return nil, err
 		}
@@ -242,7 +241,7 @@ func defaultDialOptions(serverCertPath, macaroonPath string) ([]grpc.DialOption,
 // gRPC dial options from it.
 func readMacaroon(macaroonPath string) (grpc.DialOption, error) {
 	// Load the specified macaroon file.
-	macBytes, err := ioutil.ReadFile(macaroonPath)
+	macBytes, err := os.ReadFile(macaroonPath)
 	if err != nil {
 		return nil, fmt.Errorf("unable to read macaroon path : %v", err)
 	}

--- a/itest/tarod_harness.go
+++ b/itest/tarod_harness.go
@@ -54,7 +54,9 @@ type tarodConfig struct {
 
 // newTarodHarness creates a new tarod server harness with the given
 // configuration.
-func newTarodHarness(ht *harnessTest, cfg tarodConfig) (*tarodHarness, error) {
+func newTarodHarness(ht *harnessTest, cfg tarodConfig,
+	enableHashMail bool) (*tarodHarness, error) {
+
 	if cfg.BaseDir == "" {
 		var err error
 		cfg.BaseDir, err = os.MkdirTemp("", "itest-tarod")
@@ -114,11 +116,15 @@ func newTarodHarness(ht *harnessTest, cfg tarodConfig) (*tarodHarness, error) {
 		return nil, err
 	}
 
-	// We'll modify the config slightly here, since we don't need to use
-	// the hashmail system for integration tests.
+	// Conditionally avoid setting up the hashmail system. Many
+	// tests don't require the hashmail system.
+	//
+	// We can skip setting up the hashmail system by modifying the config.
 	//
 	// TODO(roasbeef): make local aperture instance in future
-	finalCfg.HashMailAddr = ""
+	if !enableHashMail {
+		finalCfg.HashMailAddr = ""
+	}
 
 	return &tarodHarness{
 		cfg:       &cfg,

--- a/itest/test_harness.go
+++ b/itest/test_harness.go
@@ -216,7 +216,8 @@ func nextAvailablePort() int {
 // setupHarnesses creates new server and client harnesses that are connected
 // to each other through an in-memory gRPC connection.
 func setupHarnesses(t *testing.T, ht *harnessTest,
-	lndHarness *lntest.NetworkHarness) (*tarodHarness, *serverHarness) {
+	lndHarness *lntest.NetworkHarness,
+	enableHashMail bool) (*tarodHarness, *serverHarness) {
 
 	mockServerAddr := fmt.Sprintf(
 		lntest.ListenerFormat, lntest.NextAvailablePort(),
@@ -228,6 +229,7 @@ func setupHarnesses(t *testing.T, ht *harnessTest,
 	// Create a tarod that uses Bob and connect it to the universe server.
 	tarodHarness := setupTarodHarness(
 		t, ht, lndHarness.BackendCfg, lndHarness.Alice, universeServer,
+		enableHashMail,
 	)
 	return tarodHarness, universeServer
 }
@@ -236,12 +238,12 @@ func setupHarnesses(t *testing.T, ht *harnessTest,
 // and to the given universe server.
 func setupTarodHarness(t *testing.T, ht *harnessTest,
 	backend lntest.BackendConfig, node *lntest.HarnessNode,
-	universe *serverHarness) *tarodHarness {
+	universe *serverHarness, enableHashMail bool) *tarodHarness {
 
 	tarodHarness, err := newTarodHarness(ht, tarodConfig{
 		NetParams: harnessNetParams,
 		LndNode:   node,
-	})
+	}, enableHashMail)
 	require.NoError(t, err)
 
 	// Start the tarod harness now.

--- a/itest/test_harness.go
+++ b/itest/test_harness.go
@@ -62,8 +62,9 @@ const (
 
 // testCase is a struct that holds a single test case.
 type testCase struct {
-	name string
-	test func(t *harnessTest)
+	name           string
+	test           func(t *harnessTest)
+	enableHashMail bool
 }
 
 // harnessTest wraps a regular testing.T providing enhanced error detection

--- a/itest/test_harness.go
+++ b/itest/test_harness.go
@@ -14,6 +14,7 @@ import (
 	"github.com/btcsuite/btcd/rpcclient"
 	"github.com/btcsuite/btcd/wire"
 	"github.com/go-errors/errors"
+	"github.com/lightninglabs/aperture"
 	"github.com/lightninglabs/lndclient"
 	"github.com/lightninglabs/protobuf-hex-display/jsonpb"
 	"github.com/lightninglabs/protobuf-hex-display/proto"
@@ -78,6 +79,10 @@ type harnessTest struct {
 	// current test case.
 	testCase *testCase
 
+	// apertureHarness is a reference to the current aperture harness.
+	// Will be nil if not yet set up.
+	apertureHarness *ApertureHarness
+
 	// lndHarness is a reference to the current network harness. Will be
 	// nil if not yet set up.
 	lndHarness *lntest.NetworkHarness
@@ -97,12 +102,13 @@ func (h *harnessTest) newHarnessTest(t *testing.T, net *lntest.NetworkHarness,
 	universeServer *serverHarness, tarod *tarodHarness) *harnessTest {
 
 	return &harnessTest{
-		t:              t,
-		lndHarness:     net,
-		universeServer: universeServer,
-		tarod:          tarod,
-		logWriter:      h.logWriter,
-		interceptor:    h.interceptor,
+		t:               t,
+		apertureHarness: h.apertureHarness,
+		lndHarness:      net,
+		universeServer:  universeServer,
+		tarod:           tarod,
+		logWriter:       h.logWriter,
+		interceptor:     h.interceptor,
 	}
 }
 
@@ -171,7 +177,9 @@ func (h *harnessTest) setupLogging() {
 	var err error
 	h.interceptor, err = signal.Intercept()
 	require.NoError(h.t, err)
+
 	taro.SetupLoggers(h.logWriter, h.interceptor)
+	aperture.SetupLoggers(h.logWriter, h.interceptor)
 }
 
 func (h *harnessTest) newLndClient(

--- a/itest/test_harness.go
+++ b/itest/test_harness.go
@@ -5,12 +5,10 @@ import (
 	"flag"
 	"fmt"
 	"net"
-	"path"
 	"sync/atomic"
 	"testing"
 	"time"
 
-	"github.com/btcsuite/btcd/btcutil"
 	"github.com/btcsuite/btcd/chaincfg"
 	"github.com/btcsuite/btcd/chaincfg/chainhash"
 	"github.com/btcsuite/btcd/rpcclient"
@@ -239,14 +237,9 @@ func setupTarodHarness(t *testing.T, ht *harnessTest,
 	backend lntest.BackendConfig, node *lntest.HarnessNode,
 	universe *serverHarness) *tarodHarness {
 
-	apertureDataDir := btcutil.AppDataDir("aperture", false)
-
 	tarodHarness, err := newTarodHarness(ht, tarodConfig{
-		UniverseServer: universe.serverHost,
-		ServerTLSPath:  path.Join(apertureDataDir, "tls.cert"),
-		BackendCfg:     backend,
-		NetParams:      harnessNetParams,
-		LndNode:        node,
+		NetParams: harnessNetParams,
+		LndNode:   node,
 	})
 	require.NoError(t, err)
 

--- a/itest/test_list_on_test.go
+++ b/itest/test_list_on_test.go
@@ -17,8 +17,9 @@ var testCases = []*testCase{
 		test: testAddresses,
 	},
 	{
-		name: "basic send",
-		test: testBasicSend,
+		name:           "basic send",
+		test:           testBasicSend,
+		enableHashMail: true,
 	},
 	{
 		name: "round trip send",

--- a/tarocfg/config.go
+++ b/tarocfg/config.go
@@ -201,7 +201,9 @@ type Config struct {
 
 	BatchMintingInterval time.Duration `long:"batch-minting-interval" description:"A duration (1m, 2h, etc) that governs how frequently pending assets are gather into a batch to be minted."`
 
-	HashMailAddr string `long:"hashmailaddr" description:"The full host:port that should be used to optionally deliver proofs files for asynchronous sends"`
+	// The following options are used to configure the proof courier.
+	ProofCourierMode string              `long:"proofcouriermode" choice:"hashmail" description:"Type of proof courier to use."`
+	HashMailCourier  *HashMailCourierCfg `group:"proofcourier" namespace:"hashmailproofcourier"`
 
 	ChainConf *ChainConfig
 	RpcConf   *RpcConfig
@@ -228,6 +230,12 @@ type Config struct {
 	restListeners []net.Addr
 
 	net tor.Net
+}
+
+// HashMailCourierCfg is the config for the hashmail proof courier.
+type HashMailCourierCfg struct {
+	Addr        string `long:"addr" description:"The full host:port of the hashmail service which is used to deliver proofs"`
+	TlsCertPath string `long:"tlscertpath" description:"Service TLS certificate file path"`
 }
 
 // DefaultConfig returns all default values for the Config struct.
@@ -266,7 +274,10 @@ func DefaultConfig() Config {
 		},
 		LogWriter:            build.NewRotatingLogWriter(),
 		BatchMintingInterval: defaultBatchMintingInterval,
-		HashMailAddr:         defaultHashMailAddr,
+		ProofCourierMode:     "hashmail",
+		HashMailCourier: &HashMailCourierCfg{
+			Addr: defaultHashMailAddr,
+		},
 	}
 }
 

--- a/tarocfg/config.go
+++ b/tarocfg/config.go
@@ -274,7 +274,6 @@ func DefaultConfig() Config {
 		},
 		LogWriter:            build.NewRotatingLogWriter(),
 		BatchMintingInterval: defaultBatchMintingInterval,
-		ProofCourierMode:     "hashmail",
 		HashMailCourier: &HashMailCourierCfg{
 			Addr: defaultHashMailAddr,
 		},

--- a/tarocfg/server.go
+++ b/tarocfg/server.go
@@ -124,8 +124,11 @@ func CreateServerFromConfig(cfg *Config, cfgLogger btclog.Logger,
 	)
 
 	var hashMailCourier proof.Courier[address.Taro]
-	if cfg.HashMailAddr != "" {
-		hashMailBox, err := proof.NewHashMailBox(cfg.HashMailAddr)
+	if cfg.HashMailCourier != nil {
+		hashMailBox, err := proof.NewHashMailBox(
+			cfg.HashMailCourier.Addr,
+			cfg.HashMailCourier.TlsCertPath,
+		)
 		if err != nil {
 			return nil, fmt.Errorf("unable to make "+
 				"mailbox: %v", err)


### PR DESCRIPTION
This PR adds a local aperture service to the integration test framework. The aperture service is used by taro (via the hashmail system) to transfer proofs during asset transfers.