### PR TITLE
Cleanup asset commitment method names

### DIFF
--- a/commitment/asset.go
+++ b/commitment/asset.go
@@ -180,6 +180,42 @@ func NewAssetCommitment(assets ...*asset.Asset) (*AssetCommitment, error) {
 	return commitment, nil
 }
 
+// Delete modifies one entry in the AssetCommitment by deleting it in the inner
+// MS-SMT and deleting it in the internal asset map.
+func (c *AssetCommitment) Delete(asset *asset.Asset) error {
+	if asset == nil {
+		return ErrNoAssets
+	}
+
+	// The given Asset must have an ID that matches the AssetCommitment ID.
+	// The AssetCommitment ID is either a hash of the groupKey, or the ID
+	// of all the assets in the AssetCommitment.
+	if asset.TaroCommitmentKey() != c.AssetID {
+		if asset.GroupKey != nil {
+			return ErrAssetGroupKeyMismatch
+		}
+		return ErrAssetGenesisMismatch
+	}
+
+	key := asset.AssetCommitmentKey()
+
+	// TODO(bhandras): thread the context through.
+	ctx := context.TODO()
+
+	_, err := c.tree.Delete(ctx, key)
+	if err != nil {
+		return err
+	}
+
+	c.TreeRoot, err = c.tree.Root(ctx)
+	if err != nil {
+		return err
+	}
+
+	delete(c.assets, key)
+	return nil
+}
+
 // Update modifies one entry in the AssetCommitment by inserting or deleting it
 // in the inner MS-SMT and adding or deleting it in the internal asset map.
 func (c *AssetCommitment) Update(asset *asset.Asset, deletion bool) error {

--- a/commitment/asset.go
+++ b/commitment/asset.go
@@ -257,62 +257,6 @@ func (c *AssetCommitment) Delete(asset *asset.Asset) error {
 	return nil
 }
 
-// Update modifies one entry in the AssetCommitment by inserting or deleting it
-// in the inner MS-SMT and adding or deleting it in the internal asset map.
-func (c *AssetCommitment) Update(asset *asset.Asset, deletion bool) error {
-	if asset == nil {
-		return ErrNoAssets
-	}
-
-	// The given Asset must have an ID that matches the AssetCommitment ID.
-	// The AssetCommitment ID is either a hash of the groupKey, or the ID
-	// of all the assets in the AssetCommitment.
-	if asset.TaroCommitmentKey() != c.AssetID {
-		if asset.GroupKey != nil {
-			return ErrAssetGroupKeyMismatch
-		}
-		return ErrAssetGenesisMismatch
-	}
-
-	key := asset.AssetCommitmentKey()
-
-	// TODO(bhandras): thread the context through.
-	ctx := context.TODO()
-
-	if deletion {
-		_, err := c.tree.Delete(ctx, key)
-		if err != nil {
-			return err
-		}
-
-		c.TreeRoot, err = c.tree.Root(ctx)
-		if err != nil {
-			return err
-		}
-
-		delete(c.assets, key)
-		return nil
-	}
-
-	leaf, err := asset.Leaf()
-	if err != nil {
-		return err
-	}
-
-	_, err = c.tree.Insert(ctx, key, leaf)
-	if err != nil {
-		return err
-	}
-
-	c.TreeRoot, err = c.tree.Root(ctx)
-	if err != nil {
-		return err
-	}
-
-	c.assets[key] = asset
-	return nil
-}
-
 // Root computes the root identifier required to commit to this specific asset
 // commitment within the outer commitment, also known as the Taro commitment.
 func (c *AssetCommitment) Root() [sha256.Size]byte {

--- a/commitment/asset.go
+++ b/commitment/asset.go
@@ -180,6 +180,47 @@ func NewAssetCommitment(assets ...*asset.Asset) (*AssetCommitment, error) {
 	return commitment, nil
 }
 
+// Upsert modifies one entry in the AssetCommitment by inserting (or updating)
+// it in the inner MS-SMT and adding (or updating) it in the internal asset map.
+func (c *AssetCommitment) Upsert(asset *asset.Asset) error {
+	if asset == nil {
+		return ErrNoAssets
+	}
+
+	// The given Asset must have an ID that matches the AssetCommitment ID.
+	// The AssetCommitment ID is either a hash of the groupKey, or the ID
+	// of all the assets in the AssetCommitment.
+	if asset.TaroCommitmentKey() != c.AssetID {
+		if asset.GroupKey != nil {
+			return ErrAssetGroupKeyMismatch
+		}
+		return ErrAssetGenesisMismatch
+	}
+
+	key := asset.AssetCommitmentKey()
+
+	// TODO(bhandras): thread the context through.
+	ctx := context.TODO()
+
+	leaf, err := asset.Leaf()
+	if err != nil {
+		return err
+	}
+
+	_, err = c.tree.Insert(ctx, key, leaf)
+	if err != nil {
+		return err
+	}
+
+	c.TreeRoot, err = c.tree.Root(ctx)
+	if err != nil {
+		return err
+	}
+
+	c.assets[key] = asset
+	return nil
+}
+
 // Delete modifies one entry in the AssetCommitment by deleting it in the inner
 // MS-SMT and deleting it in the internal asset map.
 func (c *AssetCommitment) Delete(asset *asset.Asset) error {

--- a/commitment/commitment_test.go
+++ b/commitment/commitment_test.go
@@ -830,7 +830,7 @@ func TestUpdateAssetCommitment(t *testing.T) {
 			name: "group key mismatch",
 			f: func() (*asset.Asset, error) {
 				mismatchedAsset := randAsset(t, genesis1, groupKey2)
-				return nil, groupAssetCommitment.Update(mismatchedAsset, false)
+				return nil, groupAssetCommitment.Upsert(mismatchedAsset)
 			},
 			numAssets: 0,
 			err:       ErrAssetGroupKeyMismatch,
@@ -839,7 +839,7 @@ func TestUpdateAssetCommitment(t *testing.T) {
 			name: "genesis mismatch",
 			f: func() (*asset.Asset, error) {
 				mismatchedAsset := randAsset(t, genesis2, nil)
-				return nil, groupAssetCommitment.Update(mismatchedAsset, false)
+				return nil, groupAssetCommitment.Upsert(mismatchedAsset)
 			},
 			numAssets: 0,
 			err:       ErrAssetGenesisMismatch,
@@ -856,7 +856,7 @@ func TestUpdateAssetCommitment(t *testing.T) {
 			name: "insertion of collectible with group key",
 			f: func() (*asset.Asset, error) {
 				newAsset := randAsset(t, genesis1collect, copyOfGroupKey1)
-				return newAsset, groupAssetCommitment.Update(newAsset, false)
+				return newAsset, groupAssetCommitment.Upsert(newAsset)
 			},
 			numAssets: 2,
 			err:       nil,

--- a/commitment/commitment_test.go
+++ b/commitment/commitment_test.go
@@ -864,8 +864,8 @@ func TestUpdateAssetCommitment(t *testing.T) {
 		{
 			name: "deletion with no group key",
 			f: func() (*asset.Asset, error) {
-				return copyOfAssetNoGroup, soloAssetCommitment.Update(
-					copyOfAssetNoGroup, true,
+				return copyOfAssetNoGroup, soloAssetCommitment.Delete(
+					copyOfAssetNoGroup,
 				)
 			},
 			numAssets: 0,

--- a/tarofreighter/parcel.go
+++ b/tarofreighter/parcel.go
@@ -277,7 +277,7 @@ func (s *sendPackage) inputAnchorPkScript() ([]byte, []byte, error) {
 		inputCommitments := inputAnchorCommitmentCopy.Commitments()
 		inputCommitmentKey := inputAssetCopy.TaroCommitmentKey()
 		inputAssetTree := inputCommitments[inputCommitmentKey]
-		err = inputAssetTree.Update(inputAssetCopy, false)
+		err = inputAssetTree.Upsert(inputAssetCopy)
 		if err != nil {
 			return nil, nil, err
 		}

--- a/taroscript/send.go
+++ b/taroscript/send.go
@@ -510,7 +510,7 @@ func CreateSpendCommitments(inputCommitment *commitment.TaroCommitment,
 		return nil, ErrMissingInputAsset
 	}
 
-	if err := senderCommitment.Update(inputAsset, true); err != nil {
+	if err := senderCommitment.Delete(inputAsset); err != nil {
 		return nil, err
 	}
 

--- a/taroscript/send.go
+++ b/taroscript/send.go
@@ -540,7 +540,7 @@ func CreateSpendCommitments(inputCommitment *commitment.TaroCommitment,
 		// AssetCommitment of the sender.
 		senderStateKey = spend.NewAsset.AssetCommitmentKey()
 
-		err := senderCommitment.Update(&spend.NewAsset, false)
+		err := senderCommitment.Upsert(&spend.NewAsset)
 		if err != nil {
 			return nil, err
 		}

--- a/taroscript/send_test.go
+++ b/taroscript/send_test.go
@@ -1231,7 +1231,7 @@ var createSpendCommitmentsTestCases = []createSpendCommitmentsTestCase{
 					TaroCommitmentKey()]
 			require.True(t, ok)
 
-			err = senderCommitment.Update(&state.asset1, true)
+			err = senderCommitment.Delete(&state.asset1)
 			require.NoError(t, err)
 
 			senderTaroCommitment := state.asset1TaroTree


### PR DESCRIPTION
This change is a simple refactor which splits the asset commitment `Update` method into `Upsert` and `Delete` methods. The goal here is to make the code easier to read which will help when working on issues such as https://github.com/lightninglabs/taro/issues/241

This PR doesn't block any other PR or issue.