### PR TITLE
Cleanup taro commitment method names

### DIFF
--- a/commitment/commitment_test.go
+++ b/commitment/commitment_test.go
@@ -955,7 +955,7 @@ func TestUpdateTaroCommitment(t *testing.T) {
 
 	// Verify commitment deletion with an empty assetCommitment map
 	// and a proof of non inclusion.
-	require.NoError(t, commitment.Update(assetCommitment1, true))
+	require.NoError(t, commitment.Delete(assetCommitment1))
 	proofAsset1, _, err := commitment.Proof(
 		commitmentKey1, asset1.AssetCommitmentKey(),
 	)

--- a/commitment/commitment_test.go
+++ b/commitment/commitment_test.go
@@ -967,7 +967,7 @@ func TestUpdateTaroCommitment(t *testing.T) {
 
 	// Verify commitment insertion with a proof of inclusion and checking the
 	// assetCommitment map for the inserted assetCommitment.
-	require.NoError(t, copyOfCommitment.Update(assetCommitment2, false))
+	require.NoError(t, copyOfCommitment.Upsert(assetCommitment2))
 	proofAsset2, _, err := copyOfCommitment.Proof(
 		commitmentKey2, asset2.AssetCommitmentKey(),
 	)

--- a/commitment/taro.go
+++ b/commitment/taro.go
@@ -121,48 +121,6 @@ func (c *TaroCommitment) Delete(asset *AssetCommitment) error {
 	return nil
 }
 
-// Update modifies one entry in the TaroCommitment by inserting or deleting
-// it in the inner MS-SMT and adding or deleting it in the internal
-// AssetCommitment map.
-func (c *TaroCommitment) Update(asset *AssetCommitment, deletion bool) error {
-	if asset == nil {
-		// TODO(jhb): Concrete error types
-		panic("taro commitment update is missing asset commitment")
-	}
-
-	key := asset.TaroCommitmentKey()
-
-	// TODO(bhandras): thread the context through.
-	if deletion {
-		_, err := c.tree.Delete(context.TODO(), key)
-		if err != nil {
-			return err
-		}
-
-		c.TreeRoot, err = c.tree.Root(context.TODO())
-		if err != nil {
-			return err
-		}
-
-		delete(c.assetCommitments, key)
-	} else {
-		leaf := asset.TaroCommitmentLeaf()
-		_, err := c.tree.Insert(context.TODO(), key, leaf)
-		if err != nil {
-			return err
-		}
-
-		c.TreeRoot, err = c.tree.Root(context.TODO())
-		if err != nil {
-			return err
-		}
-
-		c.assetCommitments[key] = asset
-	}
-
-	return nil
-}
-
 // Upsert modifies one entry in the TaroCommitment by inserting (or updating)
 // it in the inner MS-SMT and in the internal AssetCommitment map.
 func (c *TaroCommitment) Upsert(asset *AssetCommitment) error {

--- a/commitment/taro.go
+++ b/commitment/taro.go
@@ -95,6 +95,32 @@ func NewTaroCommitment(assets ...*AssetCommitment) (*TaroCommitment, error) {
 	}, nil
 }
 
+// Delete modifies one entry in the TaroCommitment by deleting it in the inner
+// MS-SMT and in the internal AssetCommitment map.
+func (c *TaroCommitment) Delete(asset *AssetCommitment) error {
+	if asset == nil {
+		// TODO(jhb): Concrete error types
+		panic("taro commitment update is missing asset commitment")
+	}
+
+	key := asset.TaroCommitmentKey()
+
+	// TODO(bhandras): thread the context through.
+	_, err := c.tree.Delete(context.TODO(), key)
+	if err != nil {
+		return err
+	}
+
+	c.TreeRoot, err = c.tree.Root(context.TODO())
+	if err != nil {
+		return err
+	}
+
+	delete(c.assetCommitments, key)
+
+	return nil
+}
+
 // Update modifies one entry in the TaroCommitment by inserting or deleting
 // it in the inner MS-SMT and adding or deleting it in the internal
 // AssetCommitment map.

--- a/tarofreighter/parcel.go
+++ b/tarofreighter/parcel.go
@@ -282,7 +282,7 @@ func (s *sendPackage) inputAnchorPkScript() ([]byte, []byte, error) {
 			return nil, nil, err
 		}
 
-		err = inputAnchorCommitmentCopy.Update(inputAssetTree, false)
+		err = inputAnchorCommitmentCopy.Upsert(inputAssetTree)
 		if err != nil {
 			return nil, nil, err
 		}

--- a/taroscript/send.go
+++ b/taroscript/send.go
@@ -575,7 +575,7 @@ func CreateSpendCommitments(inputCommitment *commitment.TaroCommitment,
 	// TODO(jhb): Add emptiness check for senderCommitment, to prune the
 	// AssetCommitment entirely when possible.
 	senderTaroCommitment := *inputCommitmentCopy
-	err = senderTaroCommitment.Update(senderCommitment, false)
+	err = senderTaroCommitment.Upsert(senderCommitment)
 	if err != nil {
 		return nil, err
 	}

--- a/taroscript/send_test.go
+++ b/taroscript/send_test.go
@@ -1233,9 +1233,7 @@ var createSpendCommitmentsTestCases = []createSpendCommitmentsTestCase{
 			require.NoError(t, err)
 
 			senderTaroCommitment := state.asset1TaroTree
-			err = senderTaroCommitment.Update(
-				senderCommitment, false,
-			)
+			err = senderTaroCommitment.Upsert(senderCommitment)
 			require.NoError(t, err)
 
 			_, err = taroscript.CreateSpendCommitments(

--- a/taroscript/send_test.go
+++ b/taroscript/send_test.go
@@ -1195,9 +1195,7 @@ var createSpendCommitmentsTestCases = []createSpendCommitmentsTestCase{
 			require.True(t, ok)
 
 			senderTaroCommitment := state.asset1TaroTree
-			err = senderTaroCommitment.Update(
-				senderCommitment, true,
-			)
+			err = senderTaroCommitment.Delete(senderCommitment)
 			require.NoError(t, err)
 
 			_, err = taroscript.CreateSpendCommitments(


### PR DESCRIPTION
This change is a simple refactor which splits the taro commitment `Update` method into `Upsert` and `Delete` methods. The goal here is to make the code easier to read which will help when working on issues such as https://github.com/lightninglabs/taro/issues/241

This PR doesn't block any other PR or issue.