### PR TITLE
server: stop returning an error that is always nil

### DIFF
--- a/server.go
+++ b/server.go
@@ -36,11 +36,11 @@ type Server struct {
 }
 
 // NewServer creates a new server given the passed config.
-func NewServer(cfg *Config) (*Server, error) {
+func NewServer(cfg *Config) *Server {
 	return &Server{
 		cfg:  cfg,
 		quit: make(chan struct{}, 1),
-	}, nil
+	}
 }
 
 // RunUntilShutdown runs the main Taro server loop until a signal is received

--- a/tarocfg/server.go
+++ b/tarocfg/server.go
@@ -142,7 +142,7 @@ func CreateServerFromConfig(cfg *Config, cfgLogger btclog.Logger,
 		}
 	}
 
-	server, err := taro.NewServer(&taro.Config{
+	server := taro.NewServer(&taro.Config{
 		DebugLevel:  cfg.DebugLevel,
 		ChainParams: cfg.ActiveNetParams,
 		AssetMinter: tarogarden.NewChainPlanter(tarogarden.PlanterConfig{
@@ -208,9 +208,6 @@ func CreateServerFromConfig(cfg *Config, cfgLogger btclog.Logger,
 			TaroAddrBook: tarodbAddrBook,
 		},
 	})
-	if err != nil {
-		return nil, fmt.Errorf("unable to start server: %v", err)
-	}
 
 	return server, nil
 }


### PR DESCRIPTION
The `NewServer` function signature is `func(cfg *Config) (*Server, error)` but the error is always `nil`. Even in other projects like `loop`, `pool` or `lnd` we did not find a case were an error needed to be returned.

We can delete it from the signature from now and add it in the future (or in a wrapped function) if needed.