### PR TITLE
build: use the new merge_group selector for the merge queue

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -7,6 +7,9 @@ on:
   pull_request:
     branches:
       - "*"
+  merge_group:
+    branches:
+      - "main"
 
 defaults:
   run:


### PR DESCRIPTION
In this commit, we activate the merge queue by using the new `merge_group` selector. Without this, the CI won't report back the progress of a CI run to the merge queue, so things won't get auto merged.